### PR TITLE
Remove a console.log on a test run to keep the test output clean

### DIFF
--- a/tests/test.js
+++ b/tests/test.js
@@ -524,7 +524,6 @@ describe('imgix-javascript unit tests', function() {
 		runs(function() {
 			// ensure it actually loaded...
 			var bodyBackgroundImage = document.querySelector('body').style.backgroundImage;
-			console.log(bodyBackgroundImage);
 			expect(bodyBackgroundImage.indexOf('gradient') > -1).toBe(true);
 
 			var firstBase = bodyBackgroundImage.indexOf(baseColor),


### PR DESCRIPTION
The most minor of nits.