### PR TITLE
Allow imgix.fluid() to operate on individual nodes instead of entire document

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -264,11 +264,8 @@ imgix.helpers = {
 	},
 
 	matchesSelector: function(elem, selector) {
-		if (elem.parentNode) {
-			var children = elem.parentNode.querySelectorAll(selector);
-			return Array.prototype.slice.call(children).indexOf(elem) > -1;
-		}
-		return false;
+		var children = (elem.parentNode || document).querySelectorAll(selector);
+		return Array.prototype.slice.call(children).indexOf(elem) > -1;
 	}
 };
 

--- a/src/core.js
+++ b/src/core.js
@@ -2049,7 +2049,8 @@ imgix.FluidSet.prototype.attachWindowResizer = function() {
 
 
 /**
- * Enables fluid (responsive) images for any element(s) with the "imgix-fluid" class
+ * Enables fluid (responsive) images for any element(s) with the "imgix-fluid" class.
+ * To scope to images within a specific DOM node, pass the enclosing HTML element as the first argument.
 
 
 #####Option Descriptions
@@ -2122,9 +2123,18 @@ imgix.FluidSet.prototype.attachWindowResizer = function() {
 
  * @memberof imgix
  * @static
- * @param {object} config options for fluid (this extends the defaults)
+ * @param [rootNode=document] optional HTML element to scope operations on
+*  @param {object} config options for fluid (this extends the defaults)
  */
-imgix.fluid = function(elem) {
+imgix.fluid = function() {
+  var elem, node;
+  if (arguments.length > 0 && arguments[0].nodeType === 1) {
+    node = arguments[0];
+    elem = arguments[1];
+  } else {
+    elem = arguments[0];
+  }
+
 	if (elem === null){
 		return;
 	}
@@ -2158,10 +2168,15 @@ imgix.fluid = function(elem) {
 	var fluidElements;
 	if (elem && !imgix.helpers.isFluidSet(elem)) {
 		fluidElements = Array.isArray(elem) ? elem : [elem];
-	} else {
+  } else {
 		var cls = '' + options.fluidClass;
 		cls = cls.slice(0, 1) === '.' ? cls : ('.' + cls);
-		fluidElements = document.querySelectorAll(cls);
+    if (node && imgix.isImageElement(node)) {
+      fluidElements = [node];
+    } else {
+      var rootNode = node || document;
+      fluidElements = rootNode.querySelectorAll(cls);
+    }
 	}
 
 	for (var i = 0; i < fluidElements.length; i++) {

--- a/src/core.js
+++ b/src/core.js
@@ -2127,13 +2127,13 @@ imgix.FluidSet.prototype.attachWindowResizer = function() {
 *  @param {object} config options for fluid (this extends the defaults)
  */
 imgix.fluid = function() {
-  var elem, node;
-  if (arguments.length > 0 && arguments[0].nodeType === 1) {
-    node = arguments[0];
-    elem = arguments[1];
-  } else {
-    elem = arguments[0];
-  }
+	var elem, node;
+	if (arguments.length > 0 && arguments[0].nodeType === 1) {
+		node = arguments[0];
+		elem = arguments[1];
+	} else {
+		elem = arguments[0];
+	}
 
 	if (elem === null){
 		return;
@@ -2168,15 +2168,15 @@ imgix.fluid = function() {
 	var fluidElements;
 	if (elem && !imgix.helpers.isFluidSet(elem)) {
 		fluidElements = Array.isArray(elem) ? elem : [elem];
-  } else {
+	} else {
 		var cls = '' + options.fluidClass;
 		cls = cls.slice(0, 1) === '.' ? cls : ('.' + cls);
-    if (node && imgix.isImageElement(node)) {
-      fluidElements = [node];
-    } else {
-      var rootNode = node || document;
-      fluidElements = rootNode.querySelectorAll(cls);
-    }
+		if (node && imgix.isImageElement(node)) {
+			fluidElements = [node];
+		} else {
+			var rootNode = node || document;
+			fluidElements = rootNode.querySelectorAll(cls);
+		}
 	}
 
 	for (var i = 0; i < fluidElements.length; i++) {

--- a/src/core.js
+++ b/src/core.js
@@ -261,6 +261,14 @@ imgix.helpers = {
 		}
 
 		return '';
+	},
+
+	matchesSelector: function(elem, selector) {
+		if (elem.parentNode) {
+			var children = elem.parentNode.querySelectorAll(selector);
+			return Array.prototype.slice.call(children).indexOf(elem) > -1;
+		}
+		return false;
 	}
 };
 
@@ -2124,7 +2132,7 @@ imgix.FluidSet.prototype.attachWindowResizer = function() {
  * @memberof imgix
  * @static
  * @param [rootNode=document] optional HTML element to scope operations on
- *  @param {object} config options for fluid (this extends the defaults)
+ * @param {object} config options for fluid (this extends the defaults)
  */
 imgix.fluid = function() {
 	var elem, node;
@@ -2171,11 +2179,10 @@ imgix.fluid = function() {
 	} else {
 		var cls = '' + options.fluidClass;
 		cls = cls.slice(0, 1) === '.' ? cls : ('.' + cls);
-		if (node && imgix.isImageElement(node)) {
-			fluidElements = [node];
-		} else {
-			var rootNode = node || document;
-			fluidElements = rootNode.querySelectorAll(cls);
+		fluidElements = (node || document).querySelectorAll(cls);
+		if (node && imgix.helpers.matchesSelector(node, cls)) {
+			fluidElements = Array.prototype.slice.call(fluidElements);
+			fluidElements.unshift(node);
 		}
 	}
 

--- a/src/core.js
+++ b/src/core.js
@@ -2124,7 +2124,7 @@ imgix.FluidSet.prototype.attachWindowResizer = function() {
  * @memberof imgix
  * @static
  * @param [rootNode=document] optional HTML element to scope operations on
-*  @param {object} config options for fluid (this extends the defaults)
+ *  @param {object} config options for fluid (this extends the defaults)
  */
 imgix.fluid = function() {
 	var elem, node;

--- a/tests/test.js
+++ b/tests/test.js
@@ -859,85 +859,85 @@ describe('imgix-javascript unit tests', function() {
 		});
 	});
 
-  it('imgix.fluid given an img node as first arg', function() {
-    var el,
-        src = 'http://jackangers.imgix.net/chester.png';
+	it('imgix.fluid given an img node as first arg', function() {
+		var el,
+				src = 'http://jackangers.imgix.net/chester.png';
 
-    runs(function() {
-      el = document.createElement('img');
-      el.setAttribute('data-src', src);
-      el.setAttribute('class', 'imgix-fluid');
+		runs(function() {
+			el = document.createElement('img');
+			el.setAttribute('data-src', src);
+			el.setAttribute('class', 'imgix-fluid');
 
-      document.body.appendChild(el);
+			document.body.appendChild(el);
 
-      imgix.fluid(el);
-    });
+			imgix.fluid(el);
+		});
 
-    waitsFor(function() {
-      return el.src !== '';
-    }, 'Waiting for imgix.fluid', 5000);
+		waitsFor(function() {
+			return el.src !== '';
+		}, 'Waiting for imgix.fluid', 5000);
 
-    runs(function() {
-      expect(el.src).toMatch(/chester\.png\?/);
-      document.body.removeChild(el);
-    });
-  });
+		runs(function() {
+			expect(el.src).toMatch(/chester\.png\?/);
+			document.body.removeChild(el);
+		});
+	});
 
-  it('imgix.fluid given a containing node as first arg', function() {
-    var parent,
-        child,
-        src = 'http://jackangers.imgix.net/chester.png';
+	it('imgix.fluid given a containing node as first arg', function() {
+		var parent,
+				child,
+				src = 'http://jackangers.imgix.net/chester.png';
 
-    runs(function() {
-      child = document.createElement('img');
-      child.setAttribute('data-src', src);
-      child.setAttribute('class', 'imgix-fluid');
+		runs(function() {
+			child = document.createElement('img');
+			child.setAttribute('data-src', src);
+			child.setAttribute('class', 'imgix-fluid');
 
-      parent = document.createElement('div');
-      parent.appendChild(child);
+			parent = document.createElement('div');
+			parent.appendChild(child);
 
-      document.body.appendChild(parent);
+			document.body.appendChild(parent);
 
-      imgix.fluid(parent);
-    });
+			imgix.fluid(parent);
+		});
 
-    waitsFor(function() {
-      return child.src !== '';
-    }, 'Waiting for imgix.fluid', 5000);
+		waitsFor(function() {
+			return child.src !== '';
+		}, 'Waiting for imgix.fluid', 5000);
 
-    runs(function() {
-      expect(child.src).toMatch(/chester\.png\?/);
-      document.body.removeChild(parent);
-    });
-  });
+		runs(function() {
+			expect(child.src).toMatch(/chester\.png\?/);
+			document.body.removeChild(parent);
+		});
+	});
 
-  it('imgix.fluid respects classes when given a node', function() {
-    var parent,
-        child,
-        src = 'http://jackangers.imgix.net/chester.png';
+	it('imgix.fluid respects classes when given a node', function() {
+		var parent,
+				child,
+				src = 'http://jackangers.imgix.net/chester.png';
 
-    runs(function() {
-      child = document.createElement('img');
-      child.setAttribute('data-src', src);
-      child.setAttribute('class', 'imgix-fluid-test');
+		runs(function() {
+			child = document.createElement('img');
+			child.setAttribute('data-src', src);
+			child.setAttribute('class', 'imgix-fluid-test');
 
-      parent = document.createElement('div');
-      parent.appendChild(child);
+			parent = document.createElement('div');
+			parent.appendChild(child);
 
-      document.body.appendChild(parent);
+			document.body.appendChild(parent);
 
-      imgix.fluid(parent, {fluidClass: "imgix-fluid-test"});
-    });
+			imgix.fluid(parent, {fluidClass: "imgix-fluid-test"});
+		});
 
-    waitsFor(function() {
-      return child.src !== '';
-    }, 'Waiting for imgix.fluid', 5000);
+		waitsFor(function() {
+			return child.src !== '';
+		}, 'Waiting for imgix.fluid', 5000);
 
-    runs(function() {
-      expect(child.src).toMatch(/chester\.png\?/);
-      document.body.removeChild(parent);
-    });
-  });
+		runs(function() {
+			expect(child.src).toMatch(/chester\.png\?/);
+			document.body.removeChild(parent);
+		});
+	});
 
 	it('imgix.fluid onLoad', function() {
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -859,6 +859,86 @@ describe('imgix-javascript unit tests', function() {
 		});
 	});
 
+  it('imgix.fluid given an img node as first arg', function() {
+    var el,
+        src = 'http://jackangers.imgix.net/chester.png';
+
+    runs(function() {
+      el = document.createElement('img');
+      el.setAttribute('data-src', src);
+      el.setAttribute('class', 'imgix-fluid');
+
+      document.body.appendChild(el);
+
+      imgix.fluid(el);
+    });
+
+    waitsFor(function() {
+      return el.src !== '';
+    }, 'Waiting for imgix.fluid', 5000);
+
+    runs(function() {
+      expect(el.src).toMatch(/chester\.png\?/);
+      document.body.removeChild(el);
+    });
+  });
+
+  it('imgix.fluid given a containing node as first arg', function() {
+    var parent,
+        child,
+        src = 'http://jackangers.imgix.net/chester.png';
+
+    runs(function() {
+      child = document.createElement('img');
+      child.setAttribute('data-src', src);
+      child.setAttribute('class', 'imgix-fluid');
+
+      parent = document.createElement('div');
+      parent.appendChild(child);
+
+      document.body.appendChild(parent);
+
+      imgix.fluid(parent);
+    });
+
+    waitsFor(function() {
+      return child.src !== '';
+    }, 'Waiting for imgix.fluid', 5000);
+
+    runs(function() {
+      expect(child.src).toMatch(/chester\.png\?/);
+      document.body.removeChild(parent);
+    });
+  });
+
+  it('imgix.fluid respects classes when given a node', function() {
+    var parent,
+        child,
+        src = 'http://jackangers.imgix.net/chester.png';
+
+    runs(function() {
+      child = document.createElement('img');
+      child.setAttribute('data-src', src);
+      child.setAttribute('class', 'imgix-fluid-test');
+
+      parent = document.createElement('div');
+      parent.appendChild(child);
+
+      document.body.appendChild(parent);
+
+      imgix.fluid(parent, {fluidClass: "imgix-fluid-test"});
+    });
+
+    waitsFor(function() {
+      return child.src !== '';
+    }, 'Waiting for imgix.fluid', 5000);
+
+    runs(function() {
+      expect(child.src).toMatch(/chester\.png\?/);
+      document.body.removeChild(parent);
+    });
+  });
+
 	it('imgix.fluid onLoad', function() {
 
 		var el, opts, fl, elemSize, loaded = false, loadUpdateCount = null, loadedURLs = [];

--- a/tests/test.js
+++ b/tests/test.js
@@ -870,31 +870,7 @@ describe('imgix-javascript unit tests', function() {
 		});
 	});
 
-	it('imgix.fluid given an img node as first arg', function() {
-		var el,
-				src = 'http://jackangers.imgix.net/chester.png';
-
-		runs(function() {
-			el = document.createElement('img');
-			el.setAttribute('data-src', src);
-			el.setAttribute('class', 'imgix-fluid');
-
-			document.body.appendChild(el);
-
-			imgix.fluid(el);
-		});
-
-		waitsFor(function() {
-			return el.src !== '';
-		}, 'Waiting for imgix.fluid', 5000);
-
-		runs(function() {
-			expect(el.src).toMatch(/chester\.png\?/);
-			document.body.removeChild(el);
-		});
-	});
-
-	it('imgix.fluid given a containing node as first arg', function() {
+	it('imgix.fluid given a node', function() {
 		var parent,
 				child,
 				src = 'http://jackangers.imgix.net/chester.png';

--- a/tests/test.js
+++ b/tests/test.js
@@ -780,6 +780,17 @@ describe('imgix-javascript unit tests', function() {
 		expect(imgix.helpers.getZoom()).toEqual(1);
 	});
 
+	it('detects if an element matches a selector', function() {
+		var yes = document.createElement('div');
+		yes.setAttribute('class','imgix-fluid');
+		var no = document.createElement('div');
+		document.body.appendChild(yes);
+		document.body.appendChild(no);
+
+		expect(imgix.helpers.matchesSelector(yes, '.imgix-fluid')).toBeTruthy();
+		expect(imgix.helpers.matchesSelector(no, '.imgix-fluid')).not.toBeTruthy();
+	});
+
 	it('imgix.fluid img test', function() {
 
 		var pixelStep = 10;
@@ -894,6 +905,8 @@ describe('imgix-javascript unit tests', function() {
 			child.setAttribute('class', 'imgix-fluid');
 
 			parent = document.createElement('div');
+			parent.setAttribute('data-src', src);
+			parent.setAttribute('class', 'imgix-fluid');
 			parent.appendChild(child);
 
 			document.body.appendChild(parent);
@@ -907,6 +920,7 @@ describe('imgix-javascript unit tests', function() {
 
 		runs(function() {
 			expect(child.src).toMatch(/chester\.png\?/);
+			expect(parent.style.backgroundImage).toMatch(/chester\.png\?/);
 			document.body.removeChild(parent);
 		});
 	});


### PR DESCRIPTION
I'd like to propose this patch: allow `imgix.fluid` to take an optional first param representing a DOM node to operate on, e.g. `imgix.fluid(htmlElement, config)`.

Operating on the entire document is often overkill; our use case is a React app where the jQuery-style "run this function over a document-wide selector" is an anti-pattern. The ability to scope `fluid` to individual nodes means we can attach an `onLoad` handler that's bound to a node's corresponding React component.