### PR TITLE
Fix Safari flashing

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -373,20 +373,24 @@ imgix.setElementImage = function (el, imgUrl) {
   }
 
   if (imgix.isImageElement(el)) {
-    el.src = imgUrl;
+    if (el.src !== imgUrl) {
+      el.src = imgUrl;
+    }
     return true;
   } else {
     var curBg = imgix.getBackgroundImage(el);
-    if (curBg) {
-      el.style.cssText = el.style.cssText.replace(curBg, imgUrl);
-      return true;
-    } else {
-      if (document.addEventListener) {
-        el.style.backgroundImage = 'url(' + imgUrl + ')';
+    if (curBg !== imgUrl) {
+      if (curBg) {
+        el.style.cssText = el.style.cssText.replace(curBg, imgUrl);
+        return true;
       } else {
-        el.style.cssText = 'background-image:url(' + imgUrl + ')';
+        if (document.addEventListener) {
+          el.style.backgroundImage = 'url(' + imgUrl + ')';
+        } else {
+          el.style.cssText = 'background-image:url(' + imgUrl + ')';
+        }
+        return true;
       }
-      return true;
     }
   }
 


### PR DESCRIPTION
This patch fixes a bug reported by @ventayol. Turns out our old pal Safari (desktop and mobile) actually unsets and resets the `src` attribute of an image, even if the old and new values are identical. This causes images to flash on scroll when set to lazy-load.

cc @ventayol