### PR TITLE
Fix `display:none;` bug

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -249,7 +249,10 @@ imgix.helpers = {
         }
       }
 
-      found = val;
+      found = {
+        width: elem.offsetWidth,
+        height: elem.offsetHeight
+      };
 
       for (prop in visProp) {
         if (visProp.hasOwnProperty(prop)) {

--- a/src/core.js
+++ b/src/core.js
@@ -2036,6 +2036,10 @@ imgix.FluidSet = function (options) {
 };
 
 imgix.FluidSet.prototype.updateSrc = function (elem, pinchScale) {
+  // Short-circuit if the image is hidden
+  if (!elem.getClientRects().length) {
+    return;
+  }
 
   if (this.options.lazyLoad) {
     var view = {

--- a/src/core.js
+++ b/src/core.js
@@ -2036,8 +2036,14 @@ imgix.FluidSet = function (options) {
 };
 
 imgix.FluidSet.prototype.updateSrc = function (elem, pinchScale) {
+  // An empty src attribute throws off the 'hidden' check below,
+  // so we need to give it something to actually fill it up
+  if (elem.hasAttribute('src') && elem.getAttribute('src') === '') {
+    elem.setAttribute('src', imgix.getEmptyImage());
+  }
+
   // Short-circuit if the image is hidden
-  if (!elem.getClientRects().length) {
+  if (!elem.offsetWidth && !elem.offsetHeight && !elem.getClientRects().length) {
     return;
   }
 
@@ -2095,6 +2101,7 @@ imgix.FluidSet.prototype.updateSrc = function (elem, pinchScale) {
   if (this.options.updateOnResizeDown === false && elem.lastWidth >= currentElemWidth && elem.lastHeight >= currentElemHeight) {
     return;
   }
+
 
   if (!elem.fluidUpdateCount) {
     elem.fluidUpdateCount = 0;

--- a/tests/test.js
+++ b/tests/test.js
@@ -829,6 +829,96 @@ describe('imgix-javascript unit tests', function() {
 		});
 	});
 
+	it('doesn\'t download images when the imgix.fluid image is hidden', function() {
+		var el,
+				src = 'http://jackangers.imgix.net/chester.png',
+				checkSrc = false;
+
+		runs(function() {
+			el = document.createElement('img');
+			el.setAttribute('data-src', src);
+			el.setAttribute('class', 'imgix-fluid');
+			el.style.display = 'none';
+
+			document.body.appendChild(el);
+
+			imgix.fluid(el);
+
+			// Wait 5 seconds, then check if image has a src
+			setTimeout(function() {
+				checkSrc = !el.hasAttribute('src');
+			}, 5000);
+		});
+
+		waitsFor(function() {
+			return checkSrc;
+		}, 'The image src should not be set', 5500);
+
+		runs(function() {
+			expect(el.hasAttribute('src')).toEqual(false);
+			document.body.removeChild(el);
+		});
+	});
+
+	it('doesn\'t download images when the imgix.fluid image\'s container is hidden', function() {
+		var child,
+				parent,
+				src = 'http://jackangers.imgix.net/chester.png',
+				checkSrc = false;
+
+		runs(function() {
+			child = document.createElement('img');
+			child.setAttribute('data-src', src);
+			child.setAttribute('class', 'imgix-fluid-test');
+
+			parent = document.createElement('div');
+			parent.style.display = 'none';
+			parent.appendChild(child);
+
+			document.body.appendChild(parent);
+
+			imgix.fluid(parent, {fluidClass: "imgix-fluid-test"});
+
+			// Wait 5 seconds, then check if image has a src
+			setTimeout(function() {
+				checkSrc = !child.hasAttribute('src');
+			}, 5000);
+		});
+
+		waitsFor(function() {
+			return checkSrc;
+		}, 'The image src should not be set', 5500);
+
+		runs(function() {
+			expect(child.hasAttribute('src')).toEqual(false);
+			document.body.removeChild(parent);
+		});
+	});
+
+	it('handles imgix.fluid images with an empty src attribute', function() {
+		var el,
+				src = 'http://jackangers.imgix.net/chester.png';
+
+		runs(function() {
+			el = document.createElement('img');
+			el.setAttribute('data-src', src);
+			el.setAttribute('class', 'imgix-fluid');
+
+			document.body.appendChild(el);
+
+			imgix.fluid(el);
+		});
+
+		waitsFor(function() {
+			return el.src !== '';
+		}, 'The image src should be set', 5500);
+
+		runs(function() {
+			expect(el.src).toMatch(/chester\.png\?/);
+			document.body.removeChild(el);
+		});
+	});
+
 	it('handles imgix.fluid images with maximum dimensions', function() {
 
 		var pixelStep = 10,


### PR DESCRIPTION
This PR fixes a gnarly bug that can lead to unexpected requests for (sometimes massive) image files. This occurs for elements that have been marked as `fluid` when it tag or any of its parents are set to `display:none;`.

The root cause here is that the mechanism used to determine an element's dimensions in `imgix.calculateElementSize()` (https://github.com/imgix/imgix.js/blob/fix-displaynone/src/core.js#L240-L267) reports `{width:0, height: 0}` for all hidden elements. When the function detemines that the element being measured has no height or width, it proceeds up the chain until an un-hidden element is found, usually the `<body>` tag. Once a visible element is found, its dimensions are used to request an image and we end up with requests for images that match the width of the entire page--or, in a worst-case scenario, the *height* of the entire page.

This behavior isn't inherently wrong; `imgix.calculateElementSize()` *should* report zeroes when measuring a hidden element. The correct fix is to avoid making this calculation entirely. This patch adds a check to immediately bail from the `imgix.Fluidset.updateSrc()` method when we determine that the element we're trying to update is hidden, using the same implementation as jQuery does in its [`:hidden` selector](https://github.com/jquery/jquery/blob/master/src/css/hiddenVisibleSelectors.js).

The final piece of the puzzle is to cover a the case of an `<img>` tag with an empty `src` attribute. While we *shouldn't* encourage imgix.js users to include empty `src` attributes on their tags, it hasn't been a problem before because we never bothered checking whether the element was visible or not. Now that we are, an element like `<img src=""/>` will be evaluated as hidden regardless of its `display` value, and imgix.js won't download or render its `data-src` value as expected. To cope with this, we're setting all images with an empty `src` attribute to an empty image before evaluating, to avoid this false positive.

Review: @zacman85 