### PR TITLE
Add method to include imgix.js version in requests

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1963,10 +1963,13 @@ imgix.signUrl = function (newUrl, token) {
 };
 
 imgix.versionifyUrl = function (url) {
-  url += url.indexOf('?') === -1 ? '?' : '&';
-  url += 'ixjsv=' + imgix.version;
+  var parsed = imgix.parseUrl(url),
+      versionParam = 'ixjsv';
 
-  return url;
+  parsed.params.push(versionParam);
+  parsed.paramValues[versionParam] = imgix.version;
+
+  return imgix.buildUrl(parsed);
 };
 
 imgix.isDef = function (obj) {

--- a/src/core.js
+++ b/src/core.js
@@ -7,7 +7,9 @@ var root = this;
  * `imgix` is the root namespace for all imgix client code.
  * @namespace imgix
  */
-var imgix = {};
+var imgix = {
+  version: '1.0.24'
+};
 
 // expose imgix to browser or node
 if (typeof exports !== 'undefined') {
@@ -407,7 +409,7 @@ imgix.setElementImage = function (el, imgUrl) {
  * @returns {string} url of an empty image
  */
 imgix.getEmptyImage = function () {
-  return 'https://assets.imgix.net/pixel.gif';
+  return imgix.versionifyUrl('https://assets.imgix.net/pixel.gif');
 };
 
 /**
@@ -1460,6 +1462,8 @@ imgix.URL.prototype.getUrl = function () {
     return imgix.getEmptyImage();
   }
 
+  url = imgix.versionifyUrl(url);
+
   return url;
 };
 
@@ -1956,6 +1960,13 @@ imgix.signUrl = function (newUrl, token) {
   }
 
   return newUrl;
+};
+
+imgix.versionifyUrl = function (url) {
+  url += url.indexOf('?') === -1 ? '?' : '&';
+  url += 'ixjsv=' + imgix.version;
+
+  return url;
 };
 
 imgix.isDef = function (obj) {

--- a/tests/test.js
+++ b/tests/test.js
@@ -409,6 +409,30 @@ describe('imgix-javascript unit tests', function() {
 		});
 	});
 
+	it('correctly adds imgix.js version string to the URL', function() {
+		var el, url, loadedFlag = false;
+		runs(function() {
+			el = document.createElement('img');
+			document.body.appendChild(el);
+
+			url = new imgix.URL('http://static-a.imgix.net/macaw.png');
+
+			imgix.setElementImageAfterLoad(el, url.getURL(), function() {
+				loadedFlag = true;
+			});
+		});
+
+		waitsFor(function() {
+			return loadedFlag;
+		}, "Waiting for image to load..", 10000);
+
+		runs(function() {
+			// ensure it actually loaded...
+			expect(imgix.getElementImage(el)).toMatch(/ixjsv=/);
+			document.body.removeChild(el);
+		});
+	});
+
 	it('should attachImageTo with element', function() {
 		var img, el, newUrl, loadedFlag = false;
 		runs(function() {


### PR DESCRIPTION
This will let us track usage on our backend and better isolate bugs in the future.

Quick sanity-check: @kellysutton?