### PR TITLE
Set onload prior to src to ensure callback is run

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -355,13 +355,13 @@ imgix.isImageElement = function (el) {
  */
 imgix.setElementImageAfterLoad = function (el, imgUrl, callback) {
   var img = new Image();
-  img.src = imgUrl;
   img.onload = function () {
     imgix.setElementImage(el, imgUrl);
     if (typeof callback === 'function') {
       callback(el, imgUrl);
     }
   };
+  img.src = imgUrl;
 };
 
 /**


### PR DESCRIPTION
Setting `img.src` before `img.onload` means the callback won't fire in certain cases, such as when the image is already in the browser cache (see http://stackoverflow.com/a/5933319).

Assuming it's not intentional, here's a patch. And if it is, can I ask about the use case?