### PR TITLE
Stop using `window.btoa`, use a simple hashing function instead.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -654,7 +654,7 @@ imgix.getXPathClass = function (xpath) {
   var suffix;
 
   if (xpath){
-    suffix = window.btoa(xpath);
+    suffix = imgix.hashCode(xpath);
   } else {
     suffix = (new Date()).getTime().toString(36);
   }
@@ -1039,7 +1039,7 @@ imgix.getDefaultParams = function () {
 };
 
 imgix.makeCssClass = function (url) {
-  return 'tmp_' + window.btoa(url).replace(/\W/g, '');
+  return 'tmp_' + imgix.hashCode(url);
 };
 
 imgix.injectStyleSheet = function (url) {
@@ -1887,12 +1887,17 @@ imgix.isDef = function (obj) {
   return (typeof obj !== 'undefined');
 };
 
-imgix.safe_btoa_encode = function (str) {
-  return window.btoa(str).replace(/\+/g, '-').replace(/\//g, '_');
-};
+// Adapted from http://stackoverflow.com/a/22429679
+imgix.hashCode = function (str) {
+    /*jshint bitwise:false */
+    var i, l, hval = 0x811c9dc5;
 
-imgix.safe_btoa_decode = function (str) {
-  return window.atob(str.replace(/\-+/g, '+').replace(/_+/g, '\/')); // http://
+    for (i = 0, l = str.length; i < l; i++) {
+        hval ^= str.charCodeAt(i);
+        hval += (hval << 1) + (hval << 4) + (hval << 7) + (hval << 8) + (hval << 24);
+    }
+
+    return ("0000000" + (hval >>> 0).toString(16)).substr(-8);
 };
 
 


### PR DESCRIPTION
Naively swapping in `window.btoa` as a way of "hashing" a URL after I stripped out the MD5 stuff last week turns out to have been a terrible idea!

This PR adds a simple (not secure) hashing function to solve the problem.