### PR TITLE
Low-hanging perf improvements for scroll handling

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -427,7 +427,7 @@ imgix.setElementImage = function (el, imgUrl) {
  * @returns {string} url of an empty image
  */
 imgix.getEmptyImage = function () {
-  return 'https://assets.imgix.net/pixel.gif?ixjsv=' + imgix.version;
+  return imgix.versionifyUrl('https://assets.imgix.net/pixel.gif');
 };
 
 /**
@@ -1830,18 +1830,12 @@ imgix.parseUrl = function (url) {
 };
 
 imgix.buildUrl = function (parsed) {
-  var result = parsed.protocol + '://' + parsed.host + parsed.pathname,
-      versionParam = 'ixjsv';
+  var result = parsed.protocol + '://' + parsed.host + parsed.pathname;
 
-  // Add version string, if it doesn't already exist
-  if (!parsed.paramValues[versionParam]) {
-    parsed.params.push(versionParam);
-    parsed.paramValues[versionParam] = imgix.version;
-  }
+  // Add version string to this URL
+  imgix.versionifyUrl(parsed);
 
   if (parsed.params.length > 0) {
-
-
     parsed.params = parsed.params.map(function (e) {
       return e.toLowerCase();
     });
@@ -1877,6 +1871,44 @@ imgix.buildUrl = function (parsed) {
   }
 
   return result;
+};
+
+imgix.versionifyUrl = function (target) {
+  var versionParam = 'ixjsv',
+      splitUrl,
+      result;
+
+  if (typeof target === 'string') {
+    return imgix.versionifyStringUrl(target);
+  } else {
+    return imgix.versionifyParsedUrl(target);
+  }
+};
+
+imgix.versionifyStringUrl = function (url) {
+  var versionParam = 'ixjsv',
+      splitUrl,
+      result;
+
+  splitUrl = url.split('?');
+  result = splitUrl[0] + '?' + versionParam + '=' + imgix.version;
+
+  if (!!splitUrl[1]) {
+    result += '&' + splitUrl[1];
+  }
+
+  return result;
+}
+
+imgix.versionifyParsedUrl = function (parsed) {
+  var versionParam = 'ixjsv';
+
+  if (!parsed.paramValues[versionParam]) {
+    parsed.params.push(versionParam);
+  }
+  parsed.paramValues[versionParam] = imgix.version;
+
+  return parsed;
 };
 
 imgix.isDef = function (obj) {

--- a/src/core.js
+++ b/src/core.js
@@ -2052,40 +2052,43 @@ imgix.FluidSet.prototype.getImgDetails = function (elem, zoomMultiplier) {
     pixelStep = this.options.pixelStep,
     elemSize = imgix.helpers.calculateElementSize(imgix.isImageElement(elem) ? elem.parentNode : elem),
     elemWidth = imgix.helpers.pixelRound(elemSize.width * zoomMultiplier, pixelStep),
-    elemHeight = imgix.helpers.pixelRound(elemSize.height * zoomMultiplier, pixelStep),
-    i = new imgix.URL(imgix.helpers.getImgSrc(elem));
+    elemHeight = imgix.helpers.pixelRound(elemSize.height * zoomMultiplier, pixelStep);
 
-  i.setHeight('');
-  i.setWidth('');
+  if (!elem.url) {
+    elem.url = new imgix.URL(imgix.helpers.getImgSrc(elem));
+  }
+
+  elem.url.setHeight('');
+  elem.url.setWidth('');
 
   elemWidth = Math.min(elemWidth, this.options.maxWidth);
   elemHeight = Math.min(elemHeight, this.options.maxHeight);
 
   if (dpr !== 1 && !this.options.ignoreDPR) {
-    i.setDPR(dpr);
+    elem.url.setDPR(dpr);
   }
 
   if (this.options.highDPRAutoScaleQuality && dpr > 1) {
-    i.setQuality(Math.min(Math.max(parseInt((100 / dpr), 10), 30), 75));
+    elem.url.setQuality(Math.min(Math.max(parseInt((100 / dpr), 10), 30), 75));
   }
 
   if (this.options.fitImgTagToContainerHeight && this.options.fitImgTagToContainerWidth) {
-    i.setFit('crop');
+    elem.url.setFit('crop');
   }
 
-  if (i.getFit() === 'crop') {
+  if (elem.url.getFit() === 'crop') {
     if (elemHeight > 0 && (!imgix.isImageElement(elem) || (imgix.isImageElement(elem) && this.options.fitImgTagToContainerHeight))) {
-      i.setHeight(elemHeight);
+      elem.url.setHeight(elemHeight);
     }
 
     if (elemWidth > 0 && (!imgix.isImageElement(elem) || (imgix.isImageElement(elem) && this.options.fitImgTagToContainerWidth))) {
-      i.setWidth(elemWidth);
+      elem.url.setWidth(elemWidth);
     }
   } else {
     if (elemHeight <= elemWidth) {
-      i.setWidth(elemWidth);
+      elem.url.setWidth(elemWidth);
     } else {
-      i.setHeight(elemHeight);
+      elem.url.setHeight(elemHeight);
     }
   }
 
@@ -2097,17 +2100,17 @@ imgix.FluidSet.prototype.getImgDetails = function (elem, zoomMultiplier) {
 
   var overrides = {};
   if (this.options.onChangeParamOverride !== null && typeof this.options.onChangeParamOverride === 'function') {
-    overrides = this.options.onChangeParamOverride(elemWidth, elemHeight, i.getParams(), elem);
+    overrides = this.options.onChangeParamOverride(elemWidth, elemHeight, elem.url.getParams(), elem);
   }
 
   for (var k in overrides) {
     if (overrides.hasOwnProperty(k)) {
-      i.setParam(k, overrides[k]);
+      elem.url.setParam(k, overrides[k]);
     }
   }
 
   return {
-    url: i.getURL(),
+    url: elem.url.getURL(),
     width: elemWidth,
     height: elemHeight
   };

--- a/src/core.js
+++ b/src/core.js
@@ -427,7 +427,7 @@ imgix.setElementImage = function (el, imgUrl) {
  * @returns {string} url of an empty image
  */
 imgix.getEmptyImage = function () {
-  return imgix.versionifyUrl('https://assets.imgix.net/pixel.gif');
+  return 'https://assets.imgix.net/pixel.gif?ixjsv=' + imgix.version;
 };
 
 /**
@@ -1470,8 +1470,6 @@ imgix.URL.prototype.getUrl = function () {
     return imgix.getEmptyImage();
   }
 
-  url = imgix.versionifyUrl(url);
-
   return url;
 };
 
@@ -1832,7 +1830,15 @@ imgix.parseUrl = function (url) {
 };
 
 imgix.buildUrl = function (parsed) {
-  var result = parsed.protocol + '://' + parsed.host + parsed.pathname;
+  var result = parsed.protocol + '://' + parsed.host + parsed.pathname,
+      versionParam = 'ixjsv';
+
+  // Add version string, if it doesn't already exist
+  if (!parsed.paramValues[versionParam]) {
+    parsed.params.push(versionParam);
+    parsed.paramValues[versionParam] = imgix.version;
+  }
+
   if (parsed.params.length > 0) {
 
 
@@ -1871,16 +1877,6 @@ imgix.buildUrl = function (parsed) {
   }
 
   return result;
-};
-
-imgix.versionifyUrl = function (url) {
-  var parsed = imgix.parseUrl(url),
-      versionParam = 'ixjsv';
-
-  parsed.params.push(versionParam);
-  parsed.paramValues[versionParam] = imgix.version;
-
-  return imgix.buildUrl(parsed);
 };
 
 imgix.isDef = function (obj) {


### PR DESCRIPTION
This PR addresses two low-hanging fixes that should greatly improve scrolling performance with `imgix.fluid({lazyLoad: true})`:

- Refactor URL-versioning to not require a call to `imgix.parseUrl()`
- Cache parsed URL objects in `FluidSet.getImgDetails()` to prevent instantiating a new `imgix.URL` object for each element on each scroll event.

To be clear: this branch is *not* sufficient in the long term. This scroll-handler code is still highly inefficient and very much in need of a rewrite, and fixing it the right way will probably have to wait until we rewrite the whole library. In this PR I'm just trying to patch things up to get some immediate performance improvements until we can dedicate the eng resources needed to do this right.

In my not-quite-scientific testing, I'm seeing call times for the scroll handler reduced by 50% or more. @scashin133 Can you give this version a shot with the page you're referencing in #50, and let me know if you see a significant performance improvement?

Code review: @kellysutton 