### PR TITLE
Added fast installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ imgix.js [![Build Status](https://travis-ci.org/imgix/imgix.js.svg?branch=master
 
 The Javascript client library for [imgix](http://www.imgix.com).
 
+* [Installation](#installation)
 * [Getting Started](#getting-started)
 * [Examples](#examples)
 * [Documentation](#docs)
@@ -12,6 +13,15 @@ The Javascript client library for [imgix](http://www.imgix.com).
 * [Browser Support](#browser-support)
 * [Polyfills](#polyfills)
 * [Dependencies](#dependencies)
+
+<a name="installation"></a>
+Installation
+---------------
+
++ **npm**: `npm install imgix.js`
++ **bower**: `bower install imgix.js`
++ **Manual**: [Download](https://github.com/imgix/imgix.js/archive/master.zip) and use `dist/imgix.js`
+
 
 <a name="getting-started"></a>
 Getting Started


### PR DESCRIPTION
Although it might seem obvious, the `name` of the package is not always obvious. Most of times it is different, and some are the same as the repo name. I thought it was `imgix`, and unfortunately `npm` found a package named that way and installed. Took me 30 minutes to figure out...