### PR TITLE
Ensure `crossorigin` attribute is respected

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -379,6 +379,10 @@ imgix.setElementImageAfterLoad = function (el, imgUrl, callback) {
       callback(el, imgUrl);
     }
   };
+  if (el.hasAttribute('crossorigin')) {
+    img.setAttribute('crossorigin', el.getAttribute('crossorigin'));
+  }
+
   img.src = imgUrl;
 };
 
@@ -1353,11 +1357,10 @@ imgix.URL.prototype._handleAutoUpdate = function () {
     if (!(imgUrl in imgToEls)) {
       imgToEls[imgUrl] = [];
       (function () {
-        var img = document.createElement('img'),
+        var img = new Image(),
           curV = imgix.updateVersion[curSel],
           startTime = (new Date()).getTime();
 
-        img.src = imgUrl;
         img.onload = img.onerror = function () {
           if (!isVersionFresh(curV)) {
             // console.log(curV + ' is an old version -- not updating');
@@ -1382,6 +1385,11 @@ imgix.URL.prototype._handleAutoUpdate = function () {
             }
           }
         };
+        if (el.hasAttribute('crossorigin')) {
+          img.setAttribute('crossorigin', el.getAttribute('crossorigin'));
+        }
+
+        img.src = imgUrl;
       })();
     }
 


### PR DESCRIPTION
This pull request adds checks to make sure the `crossorigin` attribute on `<img/>` tags is respected when making requests. This fixes a bug wherein images weren't being delivered with proper CORS headers.