### PR TITLE
Add react-imgix to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Javascript client library for [imgix](http://www.imgix.com).
 * [Examples](#examples)
 * [Documentation](#docs)
 * [jQuery Plugin](#jquery)
+* [Other Libraries](#other-libraries)
 * [Browser Support](#browser-support)
 * [Polyfills](#polyfills)
 * [Dependencies](#dependencies)
@@ -167,6 +168,13 @@ For example, if you wanted to add a text watermark to all your gallery images:
 ```javascript
 $('.gallery').imgix().setParams({txt: 'Copyright Chester 2015', txtclr: 'f00', txtsize:20});
 ```
+
+<a name="other-libraries"></a>
+Other Libraries
+---------------
+
+* [react-imgix](https://github.com/frederickfogerty/react-imgix) A React component for Imgix images, uses imgix.js for building urls.
+
 
 <a name="browser-support"></a>
 Legacy Browser Support


### PR DESCRIPTION
I have created [react-imgix](https://github.com/frederickfogerty/react-imgix), a simple component to render Imgix images in React. It can do some of the cool stuff that imgix.js does, such as only requesting images of the right size, cropping to faces, etc. I thought it should be included here given the increasing popularity of React. Alternatively, you guys could decide to support it yourselves, in which case I would be happy to hand it over.