### PR TITLE
Ensure port is retained when building a URL

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -1838,7 +1838,12 @@ imgix.parseUrl = function (url) {
 };
 
 imgix.buildUrl = function (parsed) {
-  var result = parsed.protocol + '://' + parsed.host + parsed.pathname;
+  var result = parsed.protocol + '://' + parsed.host;
+
+  if (parsed.port !== null && parsed.port !== '80' && parsed.port !== '443') {
+    result += ':' + parsed.port;
+  }
+  result += parsed.pathname;
 
   // Add version string to this URL
   imgix.versionifyUrl(parsed);


### PR DESCRIPTION
(Original PR is at #57)

This PR ensures that if a URL contains a port, imgix.js won't strip it out when reconstructing the URL. This PR resolves #44.