### PR TITLE
Removing the console polyfill

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -9,25 +9,6 @@
 			};
 		}
 
-		// Console-polyfill. MIT license.
-		// https://github.com/paulmillr/console-polyfill
-		// Make it safe to do console.log() always.
-		(function(con) {
-			var prop, method;
-			var empty = {};
-			var dummy = function() {};
-			var properties = 'memory'.split(',');
-			var methods = ('assert,clear,count,debug,dir,dirxml,error,exception,group,' +
-			'groupCollapsed,groupEnd,info,log,markTimeline,profile,profiles,profileEnd,' +
-			'show,table,time,timeEnd,timeline,timelineEnd,timeStamp,trace,warn').split(',');
-			while (prop = properties.pop()) {
-				con[prop] = con[prop] || empty;
-			}
-			while (method = methods.pop()) {
-				con[method] = con[method] || dummy;
-			}
-		})(window.console || {}); // Using `this` for web workers.
-
 		// mozilla's Function.bind polyfill
 		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
 		if (!Function.prototype.bind) {


### PR DESCRIPTION
This PR removes the `console` polyfill we had been including, since it's not necessary at all.

Fixes #66