### PR TITLE
Remove `.bind()` polyfill and add `--no-polyfills` tests to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ install:
   - npm config set loglevel http
   - npm install
 before_script: grunt build
-script: karma start karma-travis.conf.js
+script:
+  - grunt test:travis
+  - grunt test:travis --no-polyfills

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -129,6 +129,10 @@ module.exports = function(grunt) {
 
 			unitquick: {
 				configFile: 'karma-quick.conf.js'
+			},
+
+			ci: {
+				configFile: 'karma-travis.conf.js'
 			}
 		},
 
@@ -171,6 +175,7 @@ module.exports = function(grunt) {
 
 	grunt.registerTask('test', ['build', 'karma:unit']);
 	grunt.registerTask('test:quick', ['build', 'karma:unitquick']);
+	grunt.registerTask('test:travis', ['build', 'karma:ci']);
 
 	grunt.registerTask('doc-cleanup', 'clean up output', function() {
 		var contents = fs.readFileSync(docsApiFile, 'UTF-8');

--- a/src/fluid.js
+++ b/src/fluid.js
@@ -245,9 +245,11 @@ var scrollInstances = {},
   resizeInstances = {};
 
 imgix.FluidSet.prototype.attachScrollListener = function () {
+  var th = this;
+
   scrollInstances[this.namespace] = imgix.helpers.throttler(function () {
-    this.reload();
-  }.bind(this), this.options.throttle);
+    th.reload();
+  }, this.options.throttle);
 
   if (document.addEventListener) {
     window.addEventListener('scroll', scrollInstances[this.namespace], false);
@@ -259,11 +261,13 @@ imgix.FluidSet.prototype.attachScrollListener = function () {
 };
 
 imgix.FluidSet.prototype.attachWindowResizer = function () {
+  var th = this;
+
   resizeInstances[this.namespace] = imgix.helpers.debouncer(function () {
     if (this.windowLastWidth !== imgix.helpers.getWindowWidth() || this.windowLastHeight !== imgix.helpers.getWindowHeight()) {
-      this.reload();
+      th.reload();
     }
-  }.bind(this), this.options.debounce);
+  }, this.options.debounce);
 
   if (window.addEventListener) {
     window.addEventListener('resize', resizeInstances[this.namespace], false);

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -9,33 +9,6 @@
 			};
 		}
 
-		// mozilla's Function.bind polyfill
-		// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
-		if (!Function.prototype.bind) {
-			Function.prototype.bind = function (oThis) {
-				if (typeof this !== "function") {
-					// closest thing possible to the ECMAScript 5
-					// internal IsCallable function
-					throw new TypeError("Function.prototype.bind - what is trying to be bound is not callable");
-				}
-
-				var aArgs = Array.prototype.slice.call(arguments, 1),
-					fToBind = this,
-					fNOP = function () {},
-					fBound = function () {
-						return fToBind.apply(this instanceof fNOP && oThis
-							? this
-							: oThis,
-							aArgs.concat(Array.prototype.slice.call(arguments)));
-					};
-
-				fNOP.prototype = this.prototype;
-				fBound.prototype = new fNOP();
-
-				return fBound;
-			};
-		}
-
 		// filter polyfill: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
 		if (!Array.prototype.filter) {
 			Array.prototype.filter = function(fun/*, thisArg*/) {


### PR DESCRIPTION
This PR does two things:
- Removes the `Function.bind()` polyfill from imgix.js (only used in one place and easily replaced)
- Ensures that continuous-integration tests on Travis are run both with and without polyfills.

This PR will close #64 