### PR TITLE
Making console calls safer

### DIFF
--- a/src/colors.js
+++ b/src/colors.js
@@ -106,7 +106,7 @@ imgix.hexToRGB = function (hex) {
     g = parseInt(hex.slice(2, 4), 16);
     b = parseInt(hex.slice(4, 6), 16);
   } else {
-    console.warn('invalid hex color:', hex);
+    window.console && window.console.warn('invalid hex color:', hex);
   }
 
   return 'rgb(' + r + ', ' + g + ', ' + b + ')';

--- a/src/fluid.js
+++ b/src/fluid.js
@@ -86,7 +86,7 @@ imgix.FluidSet.prototype.updateSrc = function (elem, pinchScale) {
 
         i.getColors(16, function (colors) {
           if (!colors) {
-            console.warn('No colors found for', i.getURL(), 'for element', elem);
+            window.console && window.console.warn('No colors found for', i.getURL(), 'for element', elem);
             return;
           }
 
@@ -380,7 +380,7 @@ imgix.fluid = function () {
 
     for (var i = 0; i < passedKeys.length; i++) {
       if (goodKeys.indexOf(passedKeys[i]) === -1) {
-        console.warn('\'' + passedKeys[i] + '\' is not a valid imgix.fluid config option. See https://github.com/imgix/imgix.js/blob/master/docs/api.md#imgix.fluid for a list of valid options.');
+        window.console && window.console.warn('\'' + passedKeys[i] + '\' is not a valid imgix.fluid config option. See https://github.com/imgix/imgix.js/blob/master/docs/api.md#imgix.fluid for a list of valid options.');
       }
     }
 

--- a/src/url.js
+++ b/src/url.js
@@ -34,7 +34,7 @@ imgix.URL = function (url, imgParams) {
 imgix.URL.prototype.attachGradientTo = function (elemOrSel, baseColor, callback) {
   this.getColors(16, function (colors) {
     if (colors && colors.length < 9) {
-      console.warn('not enough colors to create a gradient');
+      window.console && window.console.warn('not enough colors to create a gradient');
       if (callback && typeof callback === 'function') {
         callback(false);
       }
@@ -207,7 +207,6 @@ imgix.URL.prototype._handleAutoUpdate = function () {
 
         img.onload = img.onerror = function () {
           if (!isVersionFresh(curV)) {
-            // console.log(curV + ' is an old version -- not updating');
             return;
           }
 
@@ -375,7 +374,7 @@ imgix.URL.prototype.clearParams = function (runUpdate) {
  */
 imgix.URL.prototype.setParams = function (dict, doOverride) {
   if (imgix.instanceOfImgixURL(dict)) {
-    console.warn('setParams warning: dictionary of imgix params expectd. imgix URL instance passed instead');
+    window.console && window.console.warn('setParams warning: dictionary of imgix params expectd. imgix URL instance passed instead');
     return;
   }
   for (var k in dict) {
@@ -411,7 +410,7 @@ imgix.URL.prototype.setParam = function (param, value, doOverride, noUpdate) {
 
   // TODO: handle aliases -- only need on build?
   if (imgix.getAllParams().indexOf(param) === -1) {
-    console.warn('\'' + param + '\' is an invalid imgix param');
+    window.console && window.console.warn('\'' + param + '\' is an invalid imgix param');
     return this;
   }
 


### PR DESCRIPTION
When I carelessly removed the `console` polyfill in 74c5cfa, I failed to realize there were still calls to `console.warn` that made it into the distributable. This PR wraps those calls to make sure they don't break old or misunderstood browser.

This PR will close #72.