### PR TITLE
Fix #76

### DIFF
--- a/src/fluid.js
+++ b/src/fluid.js
@@ -165,8 +165,14 @@ imgix.FluidSet.prototype.getImgDetails = function (elem, zoomMultiplier) {
   elemWidth = Math.min(elemWidth, this.options.maxWidth);
   elemHeight = Math.min(elemHeight, this.options.maxHeight);
 
-  if (dpr !== 1 && !this.options.ignoreDPR) {
-    elem.url.setParam('dpr', dpr);
+  if (!this.options.ignoreDPR) {
+    var hasDPR = !!elem.url.getParam('dpr');
+
+    if (hasDPR && dpr === 1) {
+      elem.url.removeParam('dpr');
+    } else {
+      elem.url.setParam('dpr', dpr);
+    }
   }
 
   if (this.options.highDPRAutoScaleQuality && dpr > 1) {

--- a/src/fluid.js
+++ b/src/fluid.js
@@ -5,6 +5,7 @@ var fluidDefaults = {
   updateOnResize: true,
   updateOnResizeDown: false,
   updateOnPinchZoom: false,
+  updateOnDPRChange: false,
   highDPRAutoScaleQuality: true,
   onChangeParamOverride: null,
   autoInsertCSSBestPractices: false,
@@ -46,8 +47,10 @@ imgix.FluidSet = function (options) {
 
   this.windowResizeEventBound = false;
   this.windowScrollEventBound = false;
+  this.windowDPRChangeEventBound = false;
   this.windowLastWidth = 0;
   this.windowLastHeight = 0;
+  this.windowLastDPR = imgix.helpers.getWindowDPR();
 };
 
 imgix.FluidSet.prototype.updateSrc = function (elem, pinchScale) {
@@ -232,6 +235,7 @@ imgix.FluidSet.prototype.reload = function () {
 
   this.windowLastWidth = imgix.helpers.getWindowWidth();
   this.windowLastHeight = imgix.helpers.getWindowHeight();
+  this.windowLastDPR = imgix.helpers.getWindowDPR();
 };
 
 imgix.FluidSet.prototype.attachGestureEvent = function (elem) {
@@ -250,7 +254,8 @@ imgix.FluidSet.prototype.attachGestureEvent = function (elem) {
 };
 
 var scrollInstances = {},
-  resizeInstances = {};
+  resizeInstances = {},
+  animationInstances = {};
 
 imgix.FluidSet.prototype.attachScrollListener = function () {
   var th = this;
@@ -286,6 +291,18 @@ imgix.FluidSet.prototype.attachWindowResizer = function () {
   this.windowResizeEventBound = true;
 };
 
+imgix.FluidSet.prototype.attachDPRChangeListener = function () {
+  var th = this;
+
+  animationInstances[this.namespace] = window.requestAnimationFrame(function() {
+    if (this.windowLastDPR !== imgix.helpers.getWindowDPR()) {
+      th.reload();
+    }
+  });
+
+  this.windowDPRChangeEventBound = true;
+};
+
 
 /**
  * Enables fluid (responsive) images for any element(s) with the 'imgix-fluid' class.
@@ -302,6 +319,9 @@ imgix.FluidSet.prototype.attachWindowResizer = function () {
 
 `updateOnPinchZoom` __boolean__ should it request a new image when pinching on a mobile
  device<br>
+
+`updateOnDPRChange` __boolean__ should it request a new image when devicePixelRatio changed. Ignored if `ignoreDPR`
+ is set to `true`<br>
 
 `highDPRAutoScaleQuality` __boolean__ should it automatically use a lower quality image on high DPR devices. This is usually nearly undetectable by a human, but offers a significant decrease in file size.<br>
 
@@ -342,6 +362,7 @@ imgix.FluidSet.prototype.attachWindowResizer = function () {
     updateOnResize: true,
     updateOnResizeDown: false,
     updateOnPinchZoom: false,
+    updateOnDPRChange: false,
     highDPRAutoScaleQuality: true,
     onChangeParamOverride: null,
     autoInsertCSSBestPractices: false,
@@ -435,6 +456,10 @@ imgix.fluid = function () {
 
   if (options.updateOnResize && !fluidSet.windowResizeEventBound) {
     fluidSet.attachWindowResizer();
+  }
+
+  if (!options.ignoreDPR && options.updateOnDPRChange && !fluidSet.windowDPRChangeEventBound) {
+    fluidSet.attachDPRChangeListener();
   }
 
   return fluidSet;

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -235,6 +235,38 @@
 
 			return getComputedStyle;
 		})(window));
+
+		// https://gist.github.com/paulirish/1579671
+		(function() {
+		  var lastTime = 0;
+		  var vendors = ['ms', 'moz', 'webkit', 'o'];
+
+		  for (var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
+		    window.requestAnimationFrame = window[vendors[x] + 'RequestAnimationFrame'];
+		    window.cancelAnimationFrame = window[vendors[x] + 'CancelAnimationFrame'] || window[vendors[x] + 'CancelRequestAnimationFrame'];
+		  }
+
+		  if (!window.requestAnimationFrame) {
+				window.requestAnimationFrame = function(callback, element) {
+		      var currTime = new Date().getTime();
+		      var timeToCall = Math.max(0, 16 - (currTime - lastTime));
+
+					var id = window.setTimeout(function() {
+	          callback(currTime + timeToCall);
+	        }, timeToCall);
+
+		      lastTime = currTime + timeToCall;
+
+		      return id;
+		    };
+			}
+
+		  if (!window.cancelAnimationFrame) {
+				window.cancelAnimationFrame = function(id) {
+		      clearTimeout(id);
+		    };
+			}
+		})(window);
 	}
 
 	if (typeof window !== 'undefined') {

--- a/tests/fluid_test.js
+++ b/tests/fluid_test.js
@@ -395,6 +395,89 @@ describe('.fluid', function() {
     });
   });
 
+  // https://github.com/imgix/imgix.js/issues/76
+  describe('Decrease DPR to 1 and resize', function() {
+    var img,
+        baseUrl = 'http://static-a.imgix.net/macaw.png?dpr=2&fit=crop',
+        parentSize,
+        options;
+
+    beforeEach(function(done) {
+      img = document.createElement('img');
+      img.setAttribute('data-src', baseUrl);
+      img.setAttribute('class', 'imgix-fluid');
+      document.body.appendChild(img);
+
+      window.devicePixelRatio = 2;
+
+      options = {
+        onLoad: done
+      };
+
+      imgix.fluid(options);
+    });
+
+    it('unset image DPR', function(done) {
+      window.devicePixelRatio = 1;
+      window.resizeTo(window.width - 1, window.height - 1);
+
+      setTimeout(function() {
+        var lookup = /dpr=(\d+)/g.exec(img.src);
+        expect(lookup).toBeNull();
+
+        done();
+      }, 2000);
+    });
+
+    afterEach(function() {
+      document.body.removeChild(img);
+      delete window.devicePixelRatio;
+    });
+  });
+
+  describe('Setting `updateOnDPRChange` to true', function() {
+    var img,
+        baseUrl = 'http://static-a.imgix.net/macaw.png?fit=crop',
+        parentSize,
+        options;
+
+    beforeEach(function(done) {
+      img = document.createElement('img');
+      img.setAttribute('data-src', baseUrl);
+      img.setAttribute('class', 'imgix-fluid');
+      document.body.appendChild(img);
+
+      window.devicePixelRatio = 1;
+
+      options = {
+        updateOnDPRChange: true,
+        ignoreDPR: false,
+        onLoad: done
+      };
+
+      imgix.fluid(options);
+    });
+
+    it('requests an image that matches the screen DPR', function(done) {
+      window.devicePixelRatio = 2;
+
+      setTimeout(function() {
+        var lookup = /dpr=(\d+)/g.exec(img.src);
+
+        expect(lookup).not.toBeNull();
+        expect(lookup).toBeArrayOfSize(2);
+        expect(parseInt(lookup[1], 10)).toEqual(2);
+
+        done();
+      }, 2000);
+    });
+
+    afterEach(function() {
+      document.body.removeChild(img);
+      delete window.devicePixelRatio;
+    });
+  });
+
   describe('Setting a maximum width', function() {
     var img,
         baseUrl = 'http://static-a.imgix.net/macaw.png',
@@ -595,4 +678,3 @@ describe('.fluid', function() {
     });
   });
 });
-


### PR DESCRIPTION
This closes #76 and adds flag `updateOnDPRChange`, which allows to update images without window resize when window moved between devices with different DPRs