### PR TITLE
Accept explicit scroll containers

### DIFF
--- a/dist/imgix.js
+++ b/dist/imgix.js
@@ -1536,7 +1536,6 @@ var fluidDefaults = {
   lazyLoadColor: null,
   lazyLoadOffsetVertical: 20,
   lazyLoadOffsetHorizontal: 20,
-  lazyLoadScrollContainers: [window],
   throttle: 200,
   maxHeight: 5000,
   maxWidth: 5000,
@@ -1772,18 +1771,10 @@ imgix.FluidSet.prototype.attachScrollListener = function () {
     th.reload();
   }, this.options.throttle);
 
-  var handler, event;
-
   if (document.addEventListener) {
-    handler = 'addEventListener';
-    event = 'scroll';
+    window.addEventListener('scroll', scrollInstances[this.namespace], false);
   } else {
-    handler = 'attachEvent';
-    event = 'onscroll';
-  }
-
-  for (var i = 0; i < this.options.lazyLoadScrollContainers.length; i++) {
-    this.options.lazyLoadScrollContainers[i][handler](event, scrollInstances[this.namespace], false);
+    window.attachEvent('onscroll', scrollInstances[this.namespace]);
   }
 
   this.windowScrollEventBound = true;

--- a/dist/imgix.js
+++ b/dist/imgix.js
@@ -1536,6 +1536,7 @@ var fluidDefaults = {
   lazyLoadColor: null,
   lazyLoadOffsetVertical: 20,
   lazyLoadOffsetHorizontal: 20,
+  lazyLoadScrollContainers: [window],
   throttle: 200,
   maxHeight: 5000,
   maxWidth: 5000,
@@ -1771,10 +1772,18 @@ imgix.FluidSet.prototype.attachScrollListener = function () {
     th.reload();
   }, this.options.throttle);
 
+  var handler, event;
+
   if (document.addEventListener) {
-    window.addEventListener('scroll', scrollInstances[this.namespace], false);
+    handler = 'addEventListener';
+    event = 'scroll';
   } else {
-    window.attachEvent('onscroll', scrollInstances[this.namespace]);
+    handler = 'attachEvent';
+    event = 'onscroll';
+  }
+
+  for (var i = 0; i < this.options.lazyLoadScrollContainers.length; i++) {
+    this.options.lazyLoadScrollContainers[i][handler](event, scrollInstances[this.namespace], false);
   }
 
   this.windowScrollEventBound = true;

--- a/src/fluid.js
+++ b/src/fluid.js
@@ -330,6 +330,8 @@ imgix.FluidSet.prototype.attachWindowResizer = function () {
 
 `lazyLoadColor` __boolean__ or __number__ or __function__ When defined the image container's background is set to a color in the image. When value is `true` use first color in the color array, when value is a `number` use that index from the color array, when value is a `function` it uses whatever color is returned by the function (`HTMLElement' el, `Array` colors)
 
+`lazyLoadScrollContainers` __array__ Adds scroll listeners to the specified elements, in order to trigger lazy-loading on images that are scrolled into view as part of an overflowed container. Defaults to `[window]`, but if this option is specified `window` is *not* automatically included.<br>
+
 `throttle` __number__ ensures scroll events fire only once every n milliseconds, throttling lazyLoad activity.<br>
 
 `maxWidth` __number__ Never set the width parameter higher than this value.<br>
@@ -356,6 +358,7 @@ imgix.FluidSet.prototype.attachWindowResizer = function () {
     lazyLoad: false,
     lazyLoadOffsetVertical: 20,
     lazyLoadOffsetHorizontal: 20,
+    lazyLoadScrollContainers: [window],
     throttle: 200,
     maxWidth: 5000,
     maxHeight: 5000,

--- a/src/fluid.js
+++ b/src/fluid.js
@@ -18,6 +18,7 @@ var fluidDefaults = {
   lazyLoadColor: null,
   lazyLoadOffsetVertical: 20,
   lazyLoadOffsetHorizontal: 20,
+  lazyLoadScrollContainers: [window],
   throttle: 200,
   maxHeight: 5000,
   maxWidth: 5000,
@@ -253,10 +254,18 @@ imgix.FluidSet.prototype.attachScrollListener = function () {
     th.reload();
   }, this.options.throttle);
 
+  var handler, event;
+
   if (document.addEventListener) {
-    window.addEventListener('scroll', scrollInstances[this.namespace], false);
+    handler = 'addEventListener';
+    event = 'scroll';
   } else {
-    window.attachEvent('onscroll', scrollInstances[this.namespace]);
+    handler = 'attachEvent';
+    event = 'onscroll';
+  }
+
+  for (var i = 0; i < this.options.lazyLoadScrollContainers.length; i++) {
+    this.options.lazyLoadScrollContainers[i][handler](event, scrollInstances[this.namespace], false);
   }
 
   this.windowScrollEventBound = true;

--- a/tests/fluid_test.js
+++ b/tests/fluid_test.js
@@ -590,7 +590,7 @@ describe('.fluid', function() {
 
       it('does not load the image at the right of the container', function() {
         _.delay(function() {
-          expect(bottomImg.src).toBeFalsy();
+          expect(rightImg.src).toBeFalsy();
           done();
         }, delay);
       });
@@ -599,7 +599,7 @@ describe('.fluid', function() {
         scrollContainer.scrollLeft = 500;
 
         _.delay(function() {
-          expect(bottomImg.src).toMatch(baseUrl);
+          expect(rightImg.src).toMatch(baseUrl);
           done();
         }, delay);
       });

--- a/tests/fluid_test.js
+++ b/tests/fluid_test.js
@@ -546,16 +546,13 @@ describe('.fluid', function() {
 
     describe('lazy-loading an explicit scroll container', function(){
       var scrollContainer,
-          leftImage,
-          rightImageImg,
+          leftImg,
+          rightImg,
           baseUrl = 'http://static-a.imgix.net/macaw.png',
           options,
           delay = 2 * 1000;
 
       beforeEach(function() {
-        document.body.style.position = 'relative';
-        document.body.style.height = height + 'px';
-
         leftImg = document.createElement('img');
         leftImg.setAttribute('data-src', baseUrl);
         leftImg.setAttribute('class', 'imgix-fluid');
@@ -573,7 +570,7 @@ describe('.fluid', function() {
         scrollContainer.appendChild(leftImg);
         scrollContainer.appendChild(rightImg);
 
-        document.body.appendChild(scrollImage);
+        document.body.appendChild(scrollContainer);
 
         options = {
           lazyLoad: true,

--- a/tests/fluid_test.js
+++ b/tests/fluid_test.js
@@ -543,6 +543,74 @@ describe('.fluid', function() {
         window.scrollTo(0, 0);
       });
     });
+
+    describe('lazy-loading an explicit scroll container', function(){
+      var scrollContainer,
+          leftImage,
+          rightImageImg,
+          baseUrl = 'http://static-a.imgix.net/macaw.png',
+          options,
+          delay = 2 * 1000;
+
+      beforeEach(function() {
+        document.body.style.position = 'relative';
+        document.body.style.height = height + 'px';
+
+        leftImg = document.createElement('img');
+        leftImg.setAttribute('data-src', baseUrl);
+        leftImg.setAttribute('class', 'imgix-fluid');
+        leftImg.style.width = '500px';
+
+        rightImg = document.createElement('img');
+        rightImg.setAttribute('data-src', baseUrl + '?mono=00ff00');
+        rightImg.setAttribute('class', 'imgix-fluid');
+        rightImg.style.width = '500px';
+
+        scrollContainer = document.createElement('div');
+        scrollContainer.style.width = '500px';
+        scrollContainer.style.overflow = 'auto';
+        scrollContainer.style.whiteSpace = 'nowrap';
+        scrollContainer.appendChild(leftImg);
+        scrollContainer.appendChild(rightImg);
+
+        document.body.appendChild(scrollImage);
+
+        options = {
+          lazyLoad: true,
+          lazyLoadScrollContainers: [scrollContainer],
+          fitImgTagToContainerWidth: false
+        };
+
+        imgix.fluid(options);
+      });
+
+      it('loads the image at the left of the container', function() {
+        _.delay(function() {
+          expect(leftImg.src).toMatch(baseUrl);
+          done();
+        }, delay);
+      });
+
+      it('does not load the image at the right of the container', function() {
+        _.delay(function() {
+          expect(bottomImg.src).toBeFalsy();
+          done();
+        }, delay);
+      });
+
+      it('loads the image at the right of the container after scrolling to it', function() {
+        scrollContainer.scrollLeft = 500;
+
+        _.delay(function() {
+          expect(bottomImg.src).toMatch(baseUrl);
+          done();
+        }, delay);
+      });
+
+      afterEach(function() {
+        document.body.removeChild(scrollContainer);
+      });
+    });
   }
 
   describe('Using lazyLoadColor', function() {


### PR DESCRIPTION
Allows user to specify which elements should listen for scroll events. Defaults to `[window]` and any override is accepted as-is, meaning `window` is not added automatically. My thinking is that since it's probably an advanced use case, may as well give the user as much control as possible.

Let me know if you'd also like me to build the release/docs and bump version as part of this PR. Thanks!