### PR TITLE
onLoad Callback Timing Fix

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -45,10 +45,13 @@ imgix.isImageElement = function (el) {
 imgix.setElementImageAfterLoad = function (el, imgUrl, callback) {
   var img = new Image();
   img.onload = function () {
+    el.onload = function() {
+      if (typeof callback === 'function') {
+        callback(el, imgUrl);
+      }
+    };
+
     imgix.setElementImage(el, imgUrl);
-    if (typeof callback === 'function') {
-      callback(el, imgUrl);
-    }
   };
   if (el.hasAttribute('crossorigin')) {
     img.setAttribute('crossorigin', el.getAttribute('crossorigin'));


### PR DESCRIPTION
In Safari in particular, occasionally a second request occurs when the
target element src is updated.

Previously the callback is fired once the preload is complete, which in
the above scenario, is before the image is truly loaded and ready for
render.

This addresses issue #92.