### PR TITLE
prevent crashing in node when doing server-side rendering

### DIFF
--- a/dist/imgix.js
+++ b/dist/imgix.js
@@ -1536,7 +1536,7 @@ var fluidDefaults = {
   lazyLoadColor: null,
   lazyLoadOffsetVertical: 20,
   lazyLoadOffsetHorizontal: 20,
-  lazyLoadScrollContainers: [window],
+  lazyLoadScrollContainers: [typeof window === 'undefined' ? null : window],
   throttle: 200,
   maxHeight: 5000,
   maxWidth: 5000,

--- a/src/fluid.js
+++ b/src/fluid.js
@@ -18,7 +18,7 @@ var fluidDefaults = {
   lazyLoadColor: null,
   lazyLoadOffsetVertical: 20,
   lazyLoadOffsetHorizontal: 20,
-  lazyLoadScrollContainers: [window],
+  lazyLoadScrollContainers: [typeof window === 'undefined' ? null : window],
   throttle: 200,
   maxHeight: 5000,
   maxWidth: 5000,


### PR DESCRIPTION
referencing window in a node module crashes node.