### PR TITLE
Fix ix-src b64 encoding issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,33 @@ If you need to display images from multiple imgix Sources, the `host` option can
 >
 ```
 
+<a name="base-64-encoded-parameters"></a>
+### Base-64 encoded parameters
+
+All of imgix's API parameters can be provided as [Base64 variants](https://docs.imgix.com/apis/url#base64-variants). This is especially useful when providing text for the `txt` parameter, or URLs for parameters such as `mark` or `blend`.
+
+When providing parameters to imgix.js via the `ix-params` attribute, note that the values for any Base64 variant parameters will be automatically base64-encoded by imgix.js, and can therefore be provided *unencoded*.
+
+``` html
+<img
+  ix-path="unsplash/hotairballoon.jpg"
+  ix-params='{
+    "txt64": "Hello, World!"
+  }'
+  alt="A hot air balloon on a sunny day"
+>
+```
+
+When providing a URL with parameters to imgix.js via the `ix-src` attribute, note that the values for any Base64 variant parameters will *not* be automatically base64-encoded by imgix.js.
+
+``` html
+<img
+  ix-src="https://assets.imgix.net/unsplash/hotairballoon.jpg?txt64=SGVsbG8sIFdvcmxkIQ"
+  alt="A hot air balloon on a sunny day"
+  sizes="100vw"
+>
+```
+
 
 <a name="what-is-the-ixlib-param"></a>
 ### What is the `ixlib` param?

--- a/spec/ImgixTagSpec.js
+++ b/spec/ImgixTagSpec.js
@@ -217,7 +217,7 @@ describe('ImgixTag', function() {
     expect(tag._extractBaseParams()).toEqual({
       page: '3',
       w: '600',
-      txt64: 'Z2liYmVyaXNo'
+      txt64: 'gibberish'
     });
   });
 

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -42,6 +42,13 @@ var ImgixTag = (function() {
 
     if (this.ixPathVal) {
       params = JSON.parse(this.ixParamsVal) || {};
+
+      // Encode any passed Base64 variant params
+      for (var key in params) {
+        if (key.substr(-2) === '64') {
+          params[key] = util.encode64(params[key]);
+        }
+      }
     } else {
       // If the user used `ix-src`, we have to extract the base params
       // from that string URL.
@@ -54,13 +61,6 @@ var ImgixTag = (function() {
         splitParam = splitParams[i].split('=');
 
         params[splitParam[0]] = splitParam[1];
-      }
-    }
-
-    // Encode any passed Base64 variant params
-    for (var key in params) {
-      if (key.substr(-2) === '64') {
-        params[key] = util.encode64(params[key]);
       }
     }
 


### PR DESCRIPTION
This PR reverts 88d6fc4d2da5ff7c706cb04a3cde009475f2f73d and f68fb2a88d06de24a89d91b73512a61cee338f1d, in an attempt to iron out some confusion about base64 parameters once and for all.

The original implementation would auto-encode base-64 parameters when provided to the `ix-params` attribute. This was implemented in an attempt to make this library behave similarly to our other OSS libraries such as [imgix-core-js]() and [imgix-rb](https://github.com/imgix/imgix-rb). This behavior allows users to provide unencoded values for `foo64`-style parameters for the sake of convenience, auto-encoding the values as the URL is generated. There's an argument to be made that this is perhaps more confusing than it is convenient, but the issue was thoroughly argued and reasoned about before implementing, and at this point it makes no sense to re-hash the decision. Keeping this behavior in line with those other libraries is a good call.

However, as of [3.0.3](https://github.com/imgix/imgix.js/releases/tag/3.0.3), imgix.js was updated to also apply this behavior to parameters provided as a part of full URLs in the `ix-src` attribute. This PR exists to undo that change.

The decision to blindly auto-encode all `foo64`-style parameters provided in the `ix-src` attribute has the unfortunate consequence of requiring users to provide fully-assembled **incorrect** URLs to this attribute in order to get imgix.js to create the correct `srcset` url.

As an example, here's a valid imgix URL that correctly uses the `txt64` parameter: [`
https://assets.imgix.net/examples/lorie.png?w=300&txtsize=40&txtalign=top%2Ccenter&txt64=cHJldHR5YmlyZHk
`](https://assets.imgix.net/examples/lorie.png?w=300&txtsize=40&txtalign=top%2Ccenter&txt64=cHJldHR5YmlyZHk)

Intuitively, I should be able to provide this URL to imgix.js by simply assigning it to the `ix-src` attribute:
```
<img ix-src="https://assets.imgix.net/examples/lorie.png?w=300&txtsize=40&txtalign=top%2Ccenter&txt64=cHJldHR5YmlyZHk">
```

However, if I do so, imgix.js will parse the URL parameters apart, base64-encode the already-encoded `txt64` parameter, and use that now-incorrect parameter value to assemble its `srcset` attribute. In order to correct for this, I would have to provide an otherwise-incorrect URL to `ix-src`, like this one: [`https://assets.imgix.net/examples/lorie.png?w=300&txtsize=40&txtalign=top%2Ccenter&txt64=prettybirdy`](https://assets.imgix.net/examples/lorie.png?w=300&txtsize=40&txtalign=top%2Ccenter&txt64=prettybirdy!)

This is counter-intuitive, confusing, and in some cases buggy behavior. For example, for sites that generate content automatically from databases or static data formats (like imgix.com, ironically), this puts a burden of parsing and mangling otherwise valid URLs on the build system in order to generate imgix.js-friendly `ix-src` attributes. Simply reversing course on the change made for 3.0.3 solves this issue neatly and cleanly.

cc @rakuista 