### PR TITLE
Allow for skipping attribute-setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![imgix logo](https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=120)
 
-# imgix.js [![Build Status](https://travis-ci.org/imgix/imgix.js.svg?branch=master)](https://travis-ci.org/imgix/imgix.js) 
+# imgix.js [![Build Status](https://travis-ci.org/imgix/imgix.js.svg?branch=master)](https://travis-ci.org/imgix/imgix.js)
 
 **This documentation is for imgix.js version `3.0.0` and up. Those using imgix.js `2.x.x` can find documentation in that version's [readme](https://github.com/imgix/imgix.js/tree/2.2.3) and [API reference](https://github.com/imgix/imgix.js/blob/2.2.3/docs/api.md).**
 
@@ -25,6 +25,7 @@ Responsive images in the browser, simplified. Pure JavaScript with zero dependen
   * [`imgix.init()` idempotency](#imgix-init-idempotency)
   * [Lazy loading With lazysizes](#lazy-loading-with-lazysizes)
   * [Custom input attributes](#custom-input-attributes)
+  * [Null output attributes](#null-output-attributes)
   * [Base-64 encoded parameters](#base-64-encoded-parameters)
   * [What is the `ixlib` param?](#what-is-the-ixlib-param)
 * [Browser Support](#browser-support)
@@ -300,6 +301,29 @@ imgix.config.srcInputAttribute = 'data-ix-src';
 imgix.config.pathInputAttribute = 'data-ix-path';
 imgix.config.paramsInputAttribute = 'data-ix-params';
 imgix.config.hostInputAttribute = 'data-ix-host';
+```
+
+<a name="null-output-attributes"></a>
+### Null Output Attributes
+
+In rare cases, it may be undesirable to have imgix.js modify the `src`, `srcset`, or `sizes` attributes of the `<img>` elements it's targeting. In such cases, you can override the default behavior by setting some configuration values to null:
+
+Using `<meta>` tags:
+
+``` html
+<head>
+  <meta property="ix:srcAttribute" content="">
+  <meta property="ix:srcsetAttribute" content="">
+  <meta property="ix:sizesAttribute" content="">
+</head>
+```
+
+Using JavaScript:
+
+``` javascript
+imgix.config.srcAttribute = null;
+imgix.config.srcsetAttribute = null;
+imgix.config.sizesAttribute = null;
 ```
 
 <a name="base-64-encoded-parameters"></a>

--- a/spec/ImgixTagSpec.js
+++ b/spec/ImgixTagSpec.js
@@ -69,6 +69,36 @@ describe('ImgixTag', function() {
       expect(global.mockElement['sizes-attribute-test']).toBeDefined();
     });
 
+    it('does not set custom `sizesAttribute` value if config.sizesAttribute is falsy', function() {
+      spyOn(global.mockElement, 'setAttribute').and.callThrough();
+
+      global.imgix.config.sizesAttribute = null;
+      new ImgixTag(global.mockElement, global.imgix.config);
+
+      expect(global.mockElement.setAttribute.calls.count()).toEqual(3);
+      expect(global.mockElement.setAttribute).not.toHaveBeenCalledWith('sizes');
+    });
+
+    it('does not set custom `srcAttribute` value if config.srcAttribute is falsy', function() {
+      spyOn(global.mockElement, 'setAttribute').and.callThrough();
+
+      global.imgix.config.srcAttribute = null;
+      new ImgixTag(global.mockElement, global.imgix.config);
+
+      expect(global.mockElement.setAttribute.calls.count()).toEqual(3);
+      expect(global.mockElement.setAttribute).not.toHaveBeenCalledWith('src');
+    });
+
+    it('does not set custom `srcsetAttribute` value if config.srcsetAttribute is falsy', function() {
+      spyOn(global.mockElement, 'setAttribute').and.callThrough();
+
+      global.imgix.config.srcsetAttribute = null;
+      new ImgixTag(global.mockElement, global.imgix.config);
+
+      expect(global.mockElement.setAttribute.calls.count()).toEqual(3);
+      expect(global.mockElement.setAttribute).not.toHaveBeenCalledWith('srcset');
+    });
+
     it('pulls from specified `srcInputAttribute` value', function() {
       global.imgix.config.srcInputAttribute = 'data-src-input-test';
 

--- a/spec/utilSpec.js
+++ b/spec/utilSpec.js
@@ -53,6 +53,36 @@ describe('utility methods', function() {
     });
   });
 
+  describe('isString', function() {
+    it('returns true when given a string value', function() {
+      expect(util.isString('Hello, world!')).toEqual(true);
+    });
+
+    it('returns false when given a number value', function() {
+      expect(util.isString(10)).toEqual(false);
+    });
+
+    it('returns false when given a boolean value', function() {
+      expect(util.isString(true)).toEqual(false);
+    });
+
+    it('returns false when given a null value', function() {
+      expect(util.isString(null)).toEqual(false);
+    });
+
+    it('returns false when given an object value', function() {
+      expect(util.isString({hello: 'world'})).toEqual(false);
+    });
+
+    it('returns false when given an array value', function() {
+      expect(util.isString(['Hello world!'])).toEqual(false);
+    });
+
+    it('returns false when given no value', function() {
+      expect(util.isString()).toEqual(false);
+    });
+  });
+
   describe('encode64', function() {
     it('correctly encodes multibyte characters', function() {
       expect(util.encode64('Hello, world! 👌💞')).toEqual('SGVsbG8sIHdvcmxkISDwn5GM8J-Sng');

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -27,10 +27,15 @@ var ImgixTag = (function() {
     this.baseUrl = this._buildBaseUrl();
     this.baseUrlWithoutQuery = this.baseUrl.split('?')[0];
 
-    this.el.setAttribute(this.settings.sizesAttribute, this.sizes());
-    this.el.setAttribute(this.settings.srcsetAttribute, this.srcset());
+    if (util.isString(this.settings.sizesAttribute)) {
+      this.el.setAttribute(this.settings.sizesAttribute, this.sizes());
+    }
 
-    if (this.el.nodeName == 'IMG') {
+    if (util.isString(this.settings.srcsetAttribute)) {
+      this.el.setAttribute(this.settings.srcsetAttribute, this.srcset());
+    }
+
+    if (util.isString(this.settings.srcAttribute) && this.el.nodeName == 'IMG') {
       this.el.setAttribute(this.settings.srcAttribute, this.src());
     }
 

--- a/src/imgix.js
+++ b/src/imgix.js
@@ -45,13 +45,11 @@ util.domReady(function() {
   util.objectEach(defaultConfig, function(defaultValue, key) {
     var metaTagValue = getMetaTagValue(key);
 
-    if (metaTagValue !== null) {
-      // Only allow boolean values for boolean configs
-      if (typeof defaultConfig[key] === 'boolean') {
-        global.imgix.config[key] = !!metaTagValue;
-      } else {
-        global.imgix.config[key] = metaTagValue;
-      }
+    // Only allow boolean values for boolean configs
+    if (typeof defaultConfig[key] === 'boolean') {
+      global.imgix.config[key] = !!metaTagValue;
+    } else {
+      global.imgix.config[key] = metaTagValue;
     }
   });
 

--- a/src/imgix.js
+++ b/src/imgix.js
@@ -6,7 +6,13 @@ var VERSION = '3.2.0';
 
 function getMetaTagValue(propertyName) {
   var metaTag = document.querySelector('meta[property="ix:' + propertyName + '"]'),
-      metaTagContent = metaTag ? metaTag.getAttribute('content') : null;
+      metaTagContent;
+
+  if (!metaTag) {
+    return;
+  }
+
+  metaTagContent = metaTag.getAttribute('content');
 
   if (metaTagContent === 'true') {
     return true;
@@ -45,11 +51,13 @@ util.domReady(function() {
   util.objectEach(defaultConfig, function(defaultValue, key) {
     var metaTagValue = getMetaTagValue(key);
 
-    // Only allow boolean values for boolean configs
-    if (typeof defaultConfig[key] === 'boolean') {
-      global.imgix.config[key] = !!metaTagValue;
-    } else {
-      global.imgix.config[key] = metaTagValue;
+    if (typeof metaTagValue !== 'undefined') {
+      // Only allow boolean values for boolean configs
+      if (typeof defaultConfig[key] === 'boolean') {
+        global.imgix.config[key] = !!metaTagValue;
+      } else {
+        global.imgix.config[key] = metaTagValue;
+      }
     }
   });
 

--- a/src/util.js
+++ b/src/util.js
@@ -45,6 +45,9 @@ module.exports = {
       }
     }
   },
+  isString: function(value) {
+    return typeof value === 'string';
+  },
   encode64: function(str) {
     var encodedUtf8Str = unescape(encodeURIComponent(str)),
         b64Str = btoa(encodedUtf8Str),


### PR DESCRIPTION
As mentioned in #121, there's a case to be made for allowing imgix.js to skip setting attributes (`src`, `srcset`, `sizes`) when it runs. This PR adds logic (and removes some) to allow this to happen. If the `srcAttribute`, `srcsetAttribute`, or `sizesAttribute` config values are set to a falsy value (either directly, or through `<meta>` tags), the corresponding attribute will not be set on images represented by an `ImageTag` object.

@719media Would you mind reviewing this for me before I merge and release it?