### PR TITLE
Don't allow a fractional maxScreenWidthRequired

### DIFF
--- a/src/targetWidths.js
+++ b/src/targetWidths.js
@@ -126,7 +126,7 @@ function targetWidths() {
         MAXIMUM_SCREEN_WIDTH,
       minScreenWidthRequired = SCREEN_STEP,
       maxScreenWidthRequired = hasWin ?
-        maxPossibleWidth * dpr :
+        Math.floor(maxPossibleWidth * dpr) :
         MAXIMUM_SCREEN_WIDTH;
 
   var width, i;


### PR DESCRIPTION
This PR addresses an issue where, given a fractional `window.devicePixelRatio` (which can occur, for example, when a browser is zoomed to 90%), we can inadvertently add a non-integer width value to the end of an image tag's `sizes` list. While most browsers seem to handle this gracefully, and the imgix service itself handles fractional `w` and `h` value correctly (we simply floor the value to the nearest integer), this behavior chunders a lot of errors into the browser console. It's unsettling!

This fixes #126.