### PR TITLE
Fix bug in `ImgixTag._extractBaseParams()`

### DIFF
--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -106,7 +106,12 @@ var ImgixTag = (function() {
         param;
     for (var key in this.baseParams) {
       param = this.baseParams[key];
-      params.push(encodeURIComponent(key) + '=' + encodeURIComponent(param));
+
+      if (typeof param === 'undefined') {
+        params.push(encodeURIComponent(key));
+      } else {
+        params.push(encodeURIComponent(key) + '=' + encodeURIComponent(param));
+      }
     }
 
     url += params.join('&');

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -57,15 +57,19 @@ var ImgixTag = (function() {
     } else {
       // If the user used `ix-src`, we have to extract the base params
       // from that string URL.
-      var lastQuestion = this.ixSrcVal.lastIndexOf('?'),
-          paramString = this.ixSrcVal.substr(lastQuestion + 1),
-          splitParams = paramString.split('&');
+      var lastQuestion = this.ixSrcVal.lastIndexOf('?');
 
       params = {};
-      for (var i = 0, splitParam; i < splitParams.length; i++) {
-        splitParam = splitParams[i].split('=');
 
-        params[splitParam[0]] = splitParam[1];
+      if (lastQuestion > -1) {
+        var paramString = this.ixSrcVal.substr(lastQuestion + 1),
+            splitParams = paramString.split('&');
+
+        for (var i = 0, splitParam; i < splitParams.length; i++) {
+          splitParam = splitParams[i].split('=');
+
+          params[splitParam[0]] = splitParam[1];
+        }
       }
     }
 


### PR DESCRIPTION
This PR addresses a bug uncovered in `ImgixTag._extractBaseParams()`. When calling this method on an element that uses the `ix-src` attribute and does not include any query parameters in its base URL, it is expected that an empty object `{}` would be output. Instead, an object with a single property was being output, where the value of that property was `undefined` and the key was the input URL. This caused the original image URL to be included in the output `srcset` as a query parameter for all generated URLs.

For example, this caused an element such as `<img ix-src="http://example.com/foo.png">` to be assigned a `srcset` where all listed URLs began with `http://example.com/foo.png?http://example.com/foo.png=undefined&w=...`.

This PR includes a fix for this bug, plus an addition to the test suite for this function to catch this case.