### PR TITLE
feat: use exponential increase for srcset widths

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "./node_modules/jasmine/bin/jasmine.js",
+		"test": "./node_modules/jasmine/bin/jasmine.js",
+		"test:watch": "chokidar \"src/*.js\" \"spec/*.js\" -c \"npm run test\"",
     "build": "mkdir -p dist && ./node_modules/browserify/bin/cmd.js ./src/imgix.js > ./dist/imgix.js && ./node_modules/uglify-js/bin/uglifyjs ./dist/imgix.js --mangle > ./dist/imgix.min.js"
   },
   "repository": {
@@ -23,6 +24,7 @@
     "atob": "^2.0.3",
     "browserify": "^13.0.0",
     "btoa": "^1.1.2",
+    "chokidar-cli": "^1.2.1",
     "gulp": "^3.9.1",
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.3",

--- a/spec/ImgixTagSpec.js
+++ b/spec/ImgixTagSpec.js
@@ -301,7 +301,7 @@ describe('ImgixTag', function() {
   });
 
   describe('#srcset', function() {
-    it('the rendered element should have a srcSet set correctly', async () => {
+    it('the rendered element should have a srcSet set correctly', () => {
       const tag = new ImgixTag(global.mockElement, global.imgix.config);
 
       const srcset = tag.el.srcset;

--- a/spec/ImgixTagSpec.js
+++ b/spec/ImgixTagSpec.js
@@ -359,7 +359,7 @@ describe('ImgixTag', function() {
       global.mockElement['ix-src'] =
         'https://assets.imgix.net/presskit/imgix-presskit.pdf?page=3&w=600&h=300';
       var tag = new ImgixTag(global.mockElement, global.imgix.config),
-        srcsetPairs = tag.srcset().split(',');
+        srcsetPairs = tag.el.srcset.split(',');
 
       for (var i = 0, srcsetPair, w, h; i < srcsetPairs.length; i++) {
         srcsetPair = srcsetPairs[i];

--- a/src/targetWidths.js
+++ b/src/targetWidths.js
@@ -1,148 +1,20 @@
-var util = require('./util.js');
-
-var MAXIMUM_SCREEN_WIDTH = 2560 * 2;
-var SCREEN_STEP = 100;
-
-// Screen data from http://mydevice.io/devices/
-
-// Phones
-var IPHONE = { cssWidth: 320, dpr: 1 };
-var IPHONE_4 = { cssWidth: 320, dpr: 2 };
-var IPHONE_6 = { cssWidth: 375, dpr: 2 };
-var LG_G3 = { cssWidth: 360, dpr: 4 };
-
-// Phablets
-var IPHONE_6_PLUS = { cssWidth: 414, dpr: 3 };
-var IPHONE_6_PLUS_LANDSCAPE = { cssWidth: 736, dpr: 3 };
-var MOTO_NEXUS_6 = { cssWidth: 412, dpr: 3.5 };
-var MOTO_NEXUS_6_LANDSCAPE = { cssWidth: 690, dpr: 3.5 };
-var LUMIA_1520 = { cssWidth: 432, dpr: 2.5 };
-var LUMIA_1520_LANDSCAPE = { cssWidth: 768, dpr: 2.5 };
-var GALAXY_NOTE_3 = { cssWidth: 360, dpr: 3 };
-var GALAXY_NOTE_3_LANDSCAPE = { cssWidth: 640, dpr: 3 };
-var GALAXY_NOTE_4 = { cssWidth: 360, dpr: 4 };
-var GALAXY_NOTE_4_LANDSCAPE = { cssWidth: 640, dpr: 4 };
-
-// Tablets
-var IPAD = { cssWidth: 768, dpr: 1 };
-var IPAD_LANDSCAPE = { cssWidth: 1024, dpr: 1 };
-var IPAD_3 = { cssWidth: 768, dpr: 2 };
-var IPAD_3_LANDSCAPE = { cssWidth: 1024, dpr: 2 };
-var IPAD_PRO = { cssWidth: 1024, dpr: 2 };
-var IPAD_PRO_LANDSCAPE = { cssWidth: 1366, dpr: 2 };
-
-// Bootstrap breakpoints
-var BOOTSTRAP_SM = { cssWidth: 576, dpr: 1 };
-var BOOTSTRAP_SM_2X = { cssWidth: 576, dpr: 2 };
-var BOOTSTRAP_MD = { cssWidth: 720, dpr: 1 };
-var BOOTSTRAP_MD_2X = { cssWidth: 720, dpr: 2 };
-var BOOTSTRAP_LG = { cssWidth: 940, dpr: 1 };
-var BOOTSTRAP_LG_2X = { cssWidth: 940, dpr: 2 };
-var BOOTSTRAP_XL = { cssWidth: 1140, dpr: 1 };
-var BOOTSTRAP_XL_2X = { cssWidth: 1140, dpr: 2 };
-
-var PHONES = [IPHONE, IPHONE_4, IPHONE_6, LG_G3];
-
-var TABLETS = [
-  IPAD,
-  IPAD_LANDSCAPE,
-  IPAD_3,
-  IPAD_3_LANDSCAPE,
-  IPAD_PRO,
-  IPAD_PRO_LANDSCAPE
-];
-
-var PHABLETS = [
-  IPHONE_6_PLUS,
-  IPHONE_6_PLUS_LANDSCAPE,
-  MOTO_NEXUS_6,
-  MOTO_NEXUS_6_LANDSCAPE,
-  LUMIA_1520,
-  LUMIA_1520_LANDSCAPE,
-  GALAXY_NOTE_3,
-  GALAXY_NOTE_3_LANDSCAPE,
-  GALAXY_NOTE_4,
-  GALAXY_NOTE_4_LANDSCAPE
-];
-
-var BOOTSTRAP_BREAKS = [
-  BOOTSTRAP_SM,
-  BOOTSTRAP_SM_2X,
-  BOOTSTRAP_MD,
-  BOOTSTRAP_MD_2X,
-  BOOTSTRAP_LG,
-  BOOTSTRAP_LG_2X,
-  BOOTSTRAP_XL,
-  BOOTSTRAP_XL_2X
-];
-
-function devices() {
-  return PHONES.concat(PHABLETS, TABLETS, BOOTSTRAP_BREAKS);
-}
-
-function deviceWidths() {
-  var device, i, len;
-  var ref = devices();
-  var widths = [];
-
-  for (i = 0, len = ref.length; i < len; i++) {
-    device = ref[i];
-    widths.push(device.cssWidth * device.dpr);
-  }
-
-  return widths;
-}
-
-// Generates an array of physical screen widths to represent
-// the different potential viewport sizes.
-//
-// We step by `SCREEN_STEP` to give some sanity to the amount
-// of widths we output.
-//
-// The upper bound is the widest known screen on the planet.
-// @return {Array} An array of {Fixnum} instances
-function screenWidths() {
-  var widths = [];
-
-  for (var i = SCREEN_STEP; i < MAXIMUM_SCREEN_WIDTH; i += SCREEN_STEP) {
-    widths.push(i);
-  }
-  widths.push(MAXIMUM_SCREEN_WIDTH);
-
-  return widths;
-}
-
-// Return the widths to generate given the input `sizes`
-// attribute.
-//
-// @return {Array} An array of {Fixnum} instances representing the unique `srcset` URLs to generate.
 function targetWidths() {
-  var hasWin = typeof window !== 'undefined',
-      allWidths = deviceWidths().concat(screenWidths()),
-      selectedWidths = [],
-      dpr = hasWin && window.devicePixelRatio ? window.devicePixelRatio : 1,
-      maxPossibleWidth = hasWin ?
-        Math.max(window.screen.availWidth, window.screen.availHeight) :
-        MAXIMUM_SCREEN_WIDTH,
-      minScreenWidthRequired = SCREEN_STEP,
-      maxScreenWidthRequired = hasWin ?
-        Math.floor(maxPossibleWidth * dpr) :
-        MAXIMUM_SCREEN_WIDTH;
+  var resolutions = [];
+  var prev = 100;
+  var INCREMENT_PERCENTAGE = 8;
+  var MAX_SIZE = 8192;
 
-  var width, i;
-  for (i = 0; i < allWidths.length; i++) {
-    width = allWidths[i];
-
-    if (width <= maxScreenWidthRequired && width >= minScreenWidthRequired) {
-      selectedWidths.push(width);
-    }
+  function ensureEven(n) {
+    return 2 * Math.round(n / 2);
   }
 
-  selectedWidths.push(maxScreenWidthRequired);
+  resolutions.push(prev);
+  while (prev <= MAX_SIZE) {
+    prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
+    resolutions.push(ensureEven(prev));
+  }
 
-  return util.uniq(selectedWidths).sort(function(x, y) {
-    return x - y;
-  });
+  return resolutions;
 }
 
 module.exports = targetWidths();

--- a/src/targetWidths.js
+++ b/src/targetWidths.js
@@ -8,10 +8,9 @@ function targetWidths() {
     return 2 * Math.round(n / 2);
   }
 
-  resolutions.push(prev);
   while (prev <= MAX_SIZE) {
-    prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
     resolutions.push(ensureEven(prev));
+    prev *= 1 + (INCREMENT_PERCENTAGE / 100) * 2;
   }
 
   return resolutions;


### PR DESCRIPTION
## Description

This PR updates the srcset width-generation logic. The widths now grow exponentially, rather than by a fixed amount. This means that the dimensions of a  rendered image are at most 8% from the "pixel-perfect" dimensions. 

## Steps to test

Ensure that tests still pass.