### PR TITLE
fix: remove support for value-less search parameters

### DIFF
--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -112,12 +112,11 @@ var ImgixTag = (function() {
       param;
     for (var key in this.baseParams) {
       param = this.baseParams[key];
-
-      if (typeof param === 'undefined') {
-        params.push(encodeURIComponent(key));
-      } else {
-        params.push(encodeURIComponent(key) + '=' + encodeURIComponent(param));
+      if (param == null) {
+        continue;
       }
+
+      params.push(encodeURIComponent(key) + '=' + encodeURIComponent(param));
     }
 
     url += params.join('&');


### PR DESCRIPTION
## Description

Currently, this library supports value-less imgix parameters. For example, passing `{valueless: undefined, w: 20}` as options will create a URL like `...image.png?valueless&w=20`. Discussing internally at imgix, this behaviour is not supported, and so this PR removes this support.

Should this be a breaking change? My vote is no because it was never supported behaviour and shouldn't have done anything when passed to imgix, but happy to make it a breaking change if needed.

## Steps To Test

None.