### PR TITLE
chore: deprecate resizing the height param when maintaining aspect ratio

### DIFF
--- a/spec/ImgixTagSpec.js
+++ b/spec/ImgixTagSpec.js
@@ -451,21 +451,6 @@ describe('ImgixTag', function() {
         prev = element;
       }
     });
-
-    it('correctly calculates `h` to maintain aspect ratio, when specified', function() {
-      global.mockElement['ix-src'] =
-        'https://assets.imgix.net/presskit/imgix-presskit.pdf?page=3&w=600&h=300';
-      var tag = new ImgixTag(global.mockElement, global.imgix.config),
-        srcsetPairs = tag.el.srcset.split(',');
-
-      for (var i = 0, srcsetPair, w, h; i < srcsetPairs.length; i++) {
-        srcsetPair = srcsetPairs[i];
-        w = parseInt(srcsetPair.match(/w=(\d+)/)[1], 10);
-        h = parseInt(srcsetPair.match(/h=(\d+)/)[1], 10);
-
-        expect(Math.round(w / 2)).toEqual(h);
-      }
-    });
   });
 
   describe('#sizes', function() {

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -158,12 +158,6 @@ var ImgixTag = (function () {
     var clonedParams = util.shallowClone(this.baseParams);
     clonedParams.w = targetWidth;
 
-    if (this.baseParams.w != null && this.baseParams.h != null) {
-      clonedParams.h = Math.round(
-        targetWidth * (this.baseParams.h / this.baseParams.w)
-      );
-    }
-
     var url = this.baseUrlWithoutQuery + '?',
       val,
       params = [];


### PR DESCRIPTION
This PR removes the logic in `ix-src` responsible for resizing the `h` (height) parameter to maintain aspect ratio when building the `srcset` attribute. With the help of the [imgix aspect ratio parameter](https://blog.imgix.com/2019/07/17/aspect-ratio-parameter-makes-cropping-even-easier), users can now achieve the same effect with the inclusion of the `ar` parameter. This should yield slightly better performance, code cleanliness, and bring the library more in line with the imgix API.
Please note, the `ar` parameter should also be used with `fit=crop` to take effect. 

----------
**Demo**
The following is an example of how to use the `ar` parameter in this library. More information on usage specifics can be found on the [imgix API docs](https://docs.imgix.com/apis/url/size/ar).
```js
<img
	ix-src="https://assets.imgix.net/examples/treefrog.jpg?w=1000&ar=2%3A1&fit=crop"
	sizes="100vw"
>
```

With the previous behavior, passing in both a `w` (width) and `h` (height) parameter would resize the height at each `srcset` pair to maintain the ratio between the two. The same effect can be achieved by passing the `ar` parameter once without the need to recalculate/resize the height. This will produce an image cropped to the specified ratio:

|        | Example srcset URL                                                      |
|--------|-------------------------------------------------------------------------|
| Before | https://assets.imgix.net/examples/treefrog.jpg?w=1000&h=500&fit=crop    |
| After  | https://assets.imgix.net/examples/treefrog.jpg?w=1000&ar=2%3A1&fit=crop |