### PR TITLE
fix: skip over tags that fail validations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,42 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/commons": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.6.0.tgz",
+      "integrity": "sha512-w4/WHG7C4WWFyE5geCieFJF6MZkbW4VAriol5KlmQXpAQdxvV0p26sqNZOW6Qyw6Y0l9K4g+cHvvczR2sEEpqg==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.15"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "JSONStream": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
@@ -171,6 +207,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-ify": {
@@ -1706,6 +1748,12 @@
         "defined": "^1.0.0",
         "minimist": "^1.1.1"
       }
+    },
+    "diff": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
     },
     "diffie-hellman": {
       "version": "5.0.3",
@@ -3997,6 +4045,12 @@
       "integrity": "sha1-h/zPrv/AtozRnVX2cilD+SnqNeo=",
       "dev": true
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -4140,6 +4194,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
       "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=",
+      "dev": true
+    },
+    "lolex": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
       "dev": true
     },
     "loud-rejection": {
@@ -4460,6 +4520,19 @@
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "nise": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.2.tgz",
+      "integrity": "sha512-/6RhOUlicRCbE9s+94qCUsyE+pKlVJ5AhIv+jEE7ESKwnbXqulKZ1FYU+XAtHHWE9TinYvAxDUJAb912PwPoWA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^4.1.0",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -4800,6 +4873,23 @@
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
       "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "3.0.0",
@@ -5304,6 +5394,21 @@
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
       "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
       "dev": true
+    },
+    "sinon": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.3",
+        "diff": "^3.5.0",
+        "lolex": "^4.2.0",
+        "nise": "^1.5.2",
+        "supports-color": "^5.5.0"
+      }
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -5958,6 +6063,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.1.tgz",
       "integrity": "sha512-C3TaO7K81YvjCgQH9Q1S3R3P3BtN3RIM8n+OvX4il1K1zgE8ZhI0op7kClgkxtutIE8hQrcrHBXvIheqKUUCxw==",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
     },
     "typedarray": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-uglify": "3.0.2",
     "jasmine": "3.5.0",
     "prettier": "1.19.1",
+    "sinon": "^7.5.0",
     "standard-version": "7.0.1",
     "uglify-js": "3.7.0"
   }

--- a/spec/ImgixTagSpec.js
+++ b/spec/ImgixTagSpec.js
@@ -171,7 +171,8 @@ describe('ImgixTag', function() {
 
     it('errors if neither `imgix.host` or `ix-host` are specified, but the passed element has `ix-path`', function() {
       global.mockElement['ix-path'] = 'dogs.jpg';
-      var expected_warning = 'You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.';
+      var expected_warning =
+        'You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.';
 
       stub = sinon.stub(console, 'warn').callsFake(function(warning) {
         expect(warning).toEqual(expected_warning);
@@ -182,7 +183,8 @@ describe('ImgixTag', function() {
 
     it('errors if `ix-src` is passed an empty string', function() {
       global.mockElement['ix-src'] = '';
-      var expected_warning = '`ix-src` cannot accept a value of empty string ""';
+      var expected_warning =
+        '`ix-src` cannot accept a value of empty string ""';
 
       stub = sinon.stub(console, 'warn').callsFake(function(warning) {
         expect(warning).toEqual(expected_warning);
@@ -193,7 +195,8 @@ describe('ImgixTag', function() {
 
     it('errors if `ix-path` is passed an empty string', function() {
       global.mockElement['ix-path'] = '';
-      var expected_warning = '`ix-path` cannot accept a value of empty string ""';
+      var expected_warning =
+        '`ix-path` cannot accept a value of empty string ""';
 
       stub = sinon.stub(console, 'warn').callsFake(function(warning) {
         expect(warning).toEqual(expected_warning);

--- a/spec/ImgixTagSpec.js
+++ b/spec/ImgixTagSpec.js
@@ -1,6 +1,7 @@
 var ImgixTag = require('../src/ImgixTag.js'),
   btoa = require('btoa'),
-  targetWidths = require('../src/targetWidths');
+  targetWidths = require('../src/targetWidths'),
+  sinon = require('sinon');
 
 const src = 'https://assets.imgix.net/presskit/imgix-presskit.pdf?page=3&w=600';
 const srcWithoutQuery = src.slice(0, src.indexOf('?'));
@@ -47,9 +48,13 @@ describe('ImgixTag', function() {
 
   describe('#initialize', function() {
     it('errors if initialized without a DOM element', function() {
-      expect(function() {
-        new ImgixTag();
-      }).toThrow();
+      var expected_warning = 'ImgixTag must be passed a DOM element.';
+
+      stub = sinon.stub(console, 'warn').callsFake(function(warning) {
+        expect(warning).toEqual(expected_warning);
+      });
+      new ImgixTag();
+      stub.restore();
     });
 
     it('does not error if initialized with a DOM element', function() {
@@ -165,12 +170,36 @@ describe('ImgixTag', function() {
     });
 
     it('errors if neither `imgix.host` or `ix-host` are specified, but the passed element has `ix-path`', function() {
-      delete global.imgix.config.host;
       global.mockElement['ix-path'] = 'dogs.jpg';
+      var expected_warning = 'You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.';
 
-      expect(function() {
-        new ImgixTag(global.mockElement, global.imgix.config);
-      }).toThrow();
+      stub = sinon.stub(console, 'warn').callsFake(function(warning) {
+        expect(warning).toEqual(expected_warning);
+      });
+      new ImgixTag(global.mockElement, global.imgix.config);
+      stub.restore();
+    });
+
+    it('errors if `ix-src` is passed an empty string', function() {
+      global.mockElement['ix-src'] = '';
+      var expected_warning = '`ix-src` cannot accept a value of empty string ""';
+
+      stub = sinon.stub(console, 'warn').callsFake(function(warning) {
+        expect(warning).toEqual(expected_warning);
+      });
+      new ImgixTag(global.mockElement, global.imgix.config);
+      stub.restore();
+    });
+
+    it('errors if `ix-path` is passed an empty string', function() {
+      global.mockElement['ix-path'] = '';
+      var expected_warning = '`ix-path` cannot accept a value of empty string ""';
+
+      stub = sinon.stub(console, 'warn').callsFake(function(warning) {
+        expect(warning).toEqual(expected_warning);
+      });
+      new ImgixTag(global.mockElement, global.imgix.config);
+      stub.restore();
     });
 
     it('does not error if `imgix.host` is specified and the passed element has `ix-path`', function() {

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -7,45 +7,51 @@ var ImgixTag = (function() {
     this.settings = opts || {};
 
     if (!this.el) {
-      throw new Error('ImgixTag must be passed a DOM element.');
+      console.warn('ImgixTag must be passed a DOM element.');
     }
+    else {
+      if (this.el.hasAttribute('ix-initialized') && !this.settings.force) {
+        return;
+      }
 
-    if (this.el.hasAttribute('ix-initialized') && !this.settings.force) {
-      return;
+      this.ixPathVal = el.getAttribute(this.settings.pathInputAttribute);
+      this.ixParamsVal = el.getAttribute(this.settings.paramsInputAttribute);
+      this.ixSrcVal = el.getAttribute(this.settings.srcInputAttribute);
+      this.ixHostVal =
+        el.getAttribute(this.settings.hostInputAttribute) || this.settings.host;
+
+      if (this.ixPathVal && !this.ixHostVal) {
+        console.warn('You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.');
+      }
+      else if (typeof this.ixPathVal === 'string' && this.ixPathVal.length == 0) {
+        console.warn('`ix-path` cannot accept a value of empty string ""');
+      }
+      else if (typeof this.ixSrcVal === 'string' && this.ixSrcVal.length == 0) {
+        console.warn('`ix-src` cannot accept a value of empty string ""');
+      }
+      else{
+        this.baseParams = this._extractBaseParams();
+        this.baseUrl = this._buildBaseUrl();
+        this.baseUrlWithoutQuery = this.baseUrl.split('?')[0];
+
+        if (util.isString(this.settings.sizesAttribute)) {
+          this.el.setAttribute(this.settings.sizesAttribute, this.sizes());
+        }
+
+        if (util.isString(this.settings.srcsetAttribute)) {
+          this.el.setAttribute(this.settings.srcsetAttribute, this.srcset());
+        }
+
+        if (
+          util.isString(this.settings.srcAttribute) &&
+          this.el.nodeName == 'IMG'
+        ) {
+          this.el.setAttribute(this.settings.srcAttribute, this.src());
+        }
+
+        this.el.setAttribute('ix-initialized', 'ix-initialized');
+      }
     }
-
-    this.ixPathVal = el.getAttribute(this.settings.pathInputAttribute);
-    this.ixParamsVal = el.getAttribute(this.settings.paramsInputAttribute);
-    this.ixSrcVal = el.getAttribute(this.settings.srcInputAttribute);
-    this.ixHostVal =
-      el.getAttribute(this.settings.hostInputAttribute) || this.settings.host;
-
-    if (this.ixPathVal && !this.ixHostVal) {
-      throw new Error(
-        'You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.'
-      );
-    }
-
-    this.baseParams = this._extractBaseParams();
-    this.baseUrl = this._buildBaseUrl();
-    this.baseUrlWithoutQuery = this.baseUrl.split('?')[0];
-
-    if (util.isString(this.settings.sizesAttribute)) {
-      this.el.setAttribute(this.settings.sizesAttribute, this.sizes());
-    }
-
-    if (util.isString(this.settings.srcsetAttribute)) {
-      this.el.setAttribute(this.settings.srcsetAttribute, this.srcset());
-    }
-
-    if (
-      util.isString(this.settings.srcAttribute) &&
-      this.el.nodeName == 'IMG'
-    ) {
-      this.el.setAttribute(this.settings.srcAttribute, this.src());
-    }
-
-    this.el.setAttribute('ix-initialized', 'ix-initialized');
   }
 
   ImgixTag.prototype._extractBaseParams = function() {

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -8,54 +8,56 @@ var ImgixTag = (function() {
 
     if (!this.el) {
       console.warn('ImgixTag must be passed a DOM element.');
-    } else {
-      if (this.el.hasAttribute('ix-initialized') && !this.settings.force) {
-        return;
-      }
-
-      this.ixPathVal = el.getAttribute(this.settings.pathInputAttribute);
-      this.ixParamsVal = el.getAttribute(this.settings.paramsInputAttribute);
-      this.ixSrcVal = el.getAttribute(this.settings.srcInputAttribute);
-      this.ixHostVal =
-        el.getAttribute(this.settings.hostInputAttribute) || this.settings.host;
-
-      if (this.ixPathVal && !this.ixHostVal) {
-        console.warn(
-          'You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.'
-        );
-      } else if (
-        typeof this.ixPathVal === 'string' &&
-        this.ixPathVal.length == 0
-      ) {
-        console.warn('`ix-path` cannot accept a value of empty string ""');
-      } else if (
-        typeof this.ixSrcVal === 'string' &&
-        this.ixSrcVal.length == 0
-      ) {
-        console.warn('`ix-src` cannot accept a value of empty string ""');
-      } else {
-        this.baseParams = this._extractBaseParams();
-        this.baseUrl = this._buildBaseUrl();
-        this.baseUrlWithoutQuery = this.baseUrl.split('?')[0];
-
-        if (util.isString(this.settings.sizesAttribute)) {
-          this.el.setAttribute(this.settings.sizesAttribute, this.sizes());
-        }
-
-        if (util.isString(this.settings.srcsetAttribute)) {
-          this.el.setAttribute(this.settings.srcsetAttribute, this.srcset());
-        }
-
-        if (
-          util.isString(this.settings.srcAttribute) &&
-          this.el.nodeName == 'IMG'
-        ) {
-          this.el.setAttribute(this.settings.srcAttribute, this.src());
-        }
-
-        this.el.setAttribute('ix-initialized', 'ix-initialized');
-      }
+      return;
     }
+
+    if (this.el.hasAttribute('ix-initialized') && !this.settings.force) {
+      return;
+    }
+
+    this.ixPathVal = el.getAttribute(this.settings.pathInputAttribute);
+    this.ixParamsVal = el.getAttribute(this.settings.paramsInputAttribute);
+    this.ixSrcVal = el.getAttribute(this.settings.srcInputAttribute);
+    this.ixHostVal =
+      el.getAttribute(this.settings.hostInputAttribute) || this.settings.host;
+
+    if (this.ixPathVal && !this.ixHostVal) {
+      console.warn(
+        'You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.'
+      );
+      return;
+    }
+
+    if (typeof this.ixPathVal === 'string' && this.ixPathVal.length == 0) {
+      console.warn('`ix-path` cannot accept a value of empty string ""');
+      return;
+    }
+
+    if (typeof this.ixSrcVal === 'string' && this.ixSrcVal.length == 0) {
+      console.warn('`ix-src` cannot accept a value of empty string ""');
+      return;
+    }
+
+    this.baseParams = this._extractBaseParams();
+    this.baseUrl = this._buildBaseUrl();
+    this.baseUrlWithoutQuery = this.baseUrl.split('?')[0];
+
+    if (util.isString(this.settings.sizesAttribute)) {
+      this.el.setAttribute(this.settings.sizesAttribute, this.sizes());
+    }
+
+    if (util.isString(this.settings.srcsetAttribute)) {
+      this.el.setAttribute(this.settings.srcsetAttribute, this.srcset());
+    }
+
+    if (
+      util.isString(this.settings.srcAttribute) &&
+      this.el.nodeName == 'IMG'
+    ) {
+      this.el.setAttribute(this.settings.srcAttribute, this.src());
+    }
+
+    this.el.setAttribute('ix-initialized', 'ix-initialized');
   }
 
   ImgixTag.prototype._extractBaseParams = function() {

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -8,8 +8,7 @@ var ImgixTag = (function() {
 
     if (!this.el) {
       console.warn('ImgixTag must be passed a DOM element.');
-    }
-    else {
+    } else {
       if (this.el.hasAttribute('ix-initialized') && !this.settings.force) {
         return;
       }
@@ -21,15 +20,20 @@ var ImgixTag = (function() {
         el.getAttribute(this.settings.hostInputAttribute) || this.settings.host;
 
       if (this.ixPathVal && !this.ixHostVal) {
-        console.warn('You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.');
-      }
-      else if (typeof this.ixPathVal === 'string' && this.ixPathVal.length == 0) {
+        console.warn(
+          'You must set a value for `imgix.config.host` or specify an `ix-host` attribute to use `ix-path` and `ix-params`.'
+        );
+      } else if (
+        typeof this.ixPathVal === 'string' &&
+        this.ixPathVal.length == 0
+      ) {
         console.warn('`ix-path` cannot accept a value of empty string ""');
-      }
-      else if (typeof this.ixSrcVal === 'string' && this.ixSrcVal.length == 0) {
+      } else if (
+        typeof this.ixSrcVal === 'string' &&
+        this.ixSrcVal.length == 0
+      ) {
         console.warn('`ix-src` cannot accept a value of empty string ""');
-      }
-      else{
+      } else {
         this.baseParams = this._extractBaseParams();
         this.baseUrl = this._buildBaseUrl();
         this.baseUrlWithoutQuery = this.baseUrl.split('?')[0];


### PR DESCRIPTION
This PR addresses two issues that can result in broken tags:
- Current validations do not catch instances of `ix-src=""` or `ix-path=""`, which can cause errors further down the line
- Throwing any error on failed validations will halt imgix.js from processing subsequent `img` or `picture` tags, even if they are valid. This PR circumvents this scenario by only processing an image if all validations are passed.