### PR TITLE
docs: restructure README header; style/text changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@
 - [Browser Support](#browser-support)
 - [Meta](#meta)
 
-<a name="overview-and-resources"></a>
 ## Overview / Resources
 
 `imgix.js` allows developers to easily generate responsive images using the `srcset` and `sizes` attributes, or the `picture` element. This lets you write a single image URL that is parsed and used to make images look great at any screen size, by using [imgix](https://imgix.com) to process and resize your images on the fly.
@@ -48,7 +47,6 @@ Below are some other articles that help explain responsive imagery, and how it c
 - [Using imgix with `<picture>`](https://docs.imgix.com/tutorials/using-imgix-picture-element). Discusses the differences between art direction and resolution switching, and provides examples of how to accomplish art direction with imgix.
 - [Responsive Images with `srcset` and imgix](https://docs.imgix.com/tutorials/responsive-images-srcset-imgix). A look into how imgix can work with `srcset` and `sizes` to serve the right image.
 
-<a name="installation"></a>
 ## Installation
 
 There are several ways to install `imgix.js`. The appropriate method depends on your project.
@@ -61,7 +59,6 @@ If your build process will re-run `dist/imgix.js` or `dist/imgix.min.js` through
 
 Once `imgix.js` has been included on the page, it will automatically run once, after the `DOMContentLoaded` event fires. This will detect and process all `img`, `picture`, and `source` tags on the page that are set up to use `imgix.js` as described in the [Usage](#usage) section of this README.
 
-<a name="configuration"></a>
 ## Configuration
 
 `imgix.js` has two important global options:
@@ -88,12 +85,10 @@ The other way is to manually set these options on the `imgix.config` object. Not
 </script>
 ```
 
-<a name="usage"></a>
 ## Usage
 
 After installation and set up are complete, one can begin adding responsive images to the page through one of few ways:
 
-<a name="ix-src"></a>
 ### `ix-src`
 
 Creates an `img` tag with the `ix-src` attribute:
@@ -128,7 +123,6 @@ This will generate HTML something like the following:
 
 Since imgix can generate as many derivative resolutions as needed, `imgix.js` calculates them programmatically, using the dimensions you specify (note that the `w` and `h` params scale appropriately to maintain the correct aspect ratio). All of this information has been placed into the `srcset` and `sizes` attributes. Because of this, imgix.js no longer needs to watch or change the `img` tag, as all responsiveness will be handled automatically by the browser as the page is resized.
 
-<a name="ix-path-and-ix-params"></a>
 ### `ix-path` and `ix-params`
 
 If [configured](#configuration) with a global `host` option, `imgix.js` can use the `ix-path` and `ix-params` attributes instead of `ix-src`. The `ix-path` attribute is used to specify the path to an image, and the `ix-params` attribute is used to define the [imgix URL API parameters](https://docs.imgix.com/apis/url) to be applied to the image. Using these two attributes instead of `ix-src` has several advantages:
@@ -154,7 +148,6 @@ Here's how the previous example would be written out using `ix-path` and `ix-par
 
 **Please note**: `ix-params` must be a valid JSON string. This means that keys and string values must be surrounded by double quotes, e.g., `"fit": "crop"`.
 
-<a name="picture-tags"></a>
 ### `picture` tags
 
 If an art-directed image is desired, `imgix.js` plays nicely with the `picture` tag. This allows for specifying more advanced responsive images, by changing properties such as the crop and aspect ratio for different screens. To get started, construct a `picture` tag with a `source` attribute for each art-directed image, and a fallback `img` tag. If new to using the `picture` tag, consider reading our [tutorial](https://docs.imgix.com/tutorials/using-imgix-picture-element) to learn more about how it works.
@@ -198,10 +191,8 @@ The `source` tags can be used with `ix-src` or `ix-path` and `ix-params`, just l
 </picture>
 ```
 
-<a name="advanced-usage"></a>
 ## Advanced Usage
 
-<a name="overriding-ix-host"></a>
 ### Overriding `ix-host`
 
 When displaying images between multiple imgix Sources, the `host` option can be overridden on any `img` or `source` tag by specifying an `ix-host` attribute in the tag:
@@ -220,7 +211,6 @@ When displaying images between multiple imgix Sources, the `host` option can be 
 >
 ```
 
-<a name="disabling-auto-initialization"></a>
 ### Disabling auto-initialization
 
 By default, `imgix.js` will automatically run as soon as the `DOMContentLoaded` event fires, immediately processing all `img` and `source` tags on the page that are set up to use `imgix.js`. This auto-initialization behavior can be disabled by including the following `meta` tag in the document's `head`:
@@ -231,7 +221,6 @@ By default, `imgix.js` will automatically run as soon as the `DOMContentLoaded` 
 </head>
 ```
 
-<a name="manually-initializing-imgix-js"></a>
 ### Manually initializing imgix.js
 
 If auto-initialization is disabled as [described above](#disabling-auto-initialization), `imgix.js` will need to be run manually in order to process the `img` and `source` tags on the page. This can be done by invoking `imgix.init()`.
@@ -245,7 +234,6 @@ imgix.init({
 });
 ```
 
-<a name="imgix-init-idempotency"></a>
 ### `imgix.init()` idempotency
 
 Whether `imgix.init()` is run automatically when the `DOMContentLoaded` event fires or [manually initialized](#manually-initializing-imgix-js), it will always be **idempotent**. This means that `img` and `source` tags that have already been processed by imgix.js will not be re-processed by subsequent calls.
@@ -258,7 +246,6 @@ imgix.init({
 })
 ```
 
-<a name="lazy-loading-with-lazysizes"></a>
 ### Lazy Loading With [lazysizes](https://github.com/aFarkas/lazysizes)
 
 If lazy loading images is desired, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use `imgix.js` with lazysizes, generate images using lazysizes-compatible attributes instead of the standard `src`, `srcset`, and `sizes` by changing some configuration settings:
@@ -281,7 +268,6 @@ imgix.config.srcsetAttribute = 'data-srcset';
 imgix.config.sizesAttribute = 'data-sizes';
 ```
 
-<a name="custom-input-attributes"></a>
 ### Custom Input Attributes
 
 `imgix.js` defaults to pulling its data from the `ix-src`, `ix-path`, `ix-params`, and `ix-host` attributes. If custom input attributes are desired, they can be specified by changing some configuration settings. This can be useful if, say, there is a concern about W3C compliance.
@@ -306,7 +292,6 @@ imgix.config.paramsInputAttribute = 'data-ix-params';
 imgix.config.hostInputAttribute = 'data-ix-host';
 ```
 
-<a name="null-output-attributes"></a>
 ### Null Output Attributes
 
 In rare cases, it may be undesirable to have `imgix.js` modify the `src`, `srcset`, or `sizes` attributes of the `<img>` elements it's targeting. In such cases, the default behavior can be overriden by setting some configuration values to `null`:
@@ -329,7 +314,6 @@ imgix.config.srcsetAttribute = null;
 imgix.config.sizesAttribute = null;
 ```
 
-<a name="base-64-encoded-parameters"></a>
 ### Base-64 encoded parameters
 
 All of imgix's API parameters can be provided as [Base64 variants](https://docs.imgix.com/apis/url#base64-variants). This is especially useful when providing text for the `txt` parameter, or URLs for parameters such as `mark` or `blend`.
@@ -356,7 +340,6 @@ When providing a URL with parameters via the `ix-src` attribute, note that the v
 >
 ```
 
-<a name="default-parameters"></a>
 ### Default parameters
 
 If a default set of parameters are desired, they can be extracted out into a global config using `imgix.defaultParameters`. These settings will become the default paramters for each imgix tag globally, before any specific parameters are loaded from `ix-params` or `ix-src`
@@ -379,7 +362,6 @@ imgix.config.defaultParams = {
 
 ```
 
-<a name="what-is-the-ixlib-param"></a>
 ### What is the `ixlib` param?
 
 For security and diagnostic purposes, we default to signing all requests with the language and version of library used to generate the URL. This can be disabled by setting the `includeLibraryParam` configuration option to `false`.
@@ -398,14 +380,11 @@ Using JavaScript:
 imgix.config.includeLibraryParam = false;
 ```
 
-
-<a name="browser-support"></a>
 ## Browser Support
 
 - By default, browsers that don't support [`srcset`](http://caniuse.com/#feat=srcset), [`sizes`](http://caniuse.com/#feat=srcset), or [`picture`](http://caniuse.com/#feat=picture) will gracefully fall back to the default `img` `src` when appropriate. If you want to provide a fully-responsive experience for these browsers, `imgix.js` works great alongside [Picturefill](https://github.com/scottjehl/picturefill)!
 - If using [Base64 variant params](https://docs.imgix.com/apis/url#base64-variants) and require IE <= 9 support, we recommend using a polyfill for `atob`/`btoa`, such as [Base64.js](https://github.com/davidchambers/Base64.js).
 
-<a name="meta"></a>
 ## Meta
 
 `imgix.js` was made by [imgix](http://imgix.com). It's licensed under the BSD 2-Clause license (see the [license file](https://github.com/imgix/imgix.js/blob/master/LICENSE.md) for more info). Any contribution is absolutely welcome, but please review the [contribution guidelines](https://github.com/imgix/imgix.js/blob/master/CONTRIBUTING.md) before getting started.

--- a/README.md
+++ b/README.md
@@ -17,31 +17,29 @@
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Usage](#usage)
-  - [ix-src](#ix-src)
-  - [ix-path and ix-params](#ix-path-and-ix-params)
-  - [picture tags](#picture-tags)
+  - [`ix-src`](#ix-src)
+  - [`ix-path` and `ix-params`](#ix-path-and-ix-params)
+  - [`picture` tags](#picture-tags)
 - [Advanced Usage](#advanced-usage)
-  - [Overriding ix-host](#overriding-ix-host)
+  - [Overriding `ix-host`](#overriding-ix-host)
   - [Disabling auto-initialization](#disabling-auto-initialization)
   - [Manually initializing imgix.js](#manually-initializing-imgixjs)
-  - [imgix.init() idempotency](#imgixinit-idempotency)
+  - [`imgix.init()` idempotency](#imgixinit-idempotency)
   - [Lazy Loading With lazysizes](#lazy-loading-with-lazysizes)
   - [Custom Input Attributes](#custom-input-attributes)
   - [Null Output Attributes](#null-output-attributes)
   - [Base-64 encoded parameters](#base-64-encoded-parameters)
   - [Default parameters](#default-parameters)
-  - [What is the ixlib param?](#what-is-the-ixlib-param)
+  - [What is the `ixlib` param?](#what-is-the-ixlib-param)
 - [Browser Support](#browser-support)
 - [Meta](#meta)
 
 <a name="overview-and-resources"></a>
 ## Overview / Resources
 
-**This documentation is for imgix.js version `3.0.0` and up. Those using imgix.js `2.x.x` can find documentation in the corresponding version's [readme](https://github.com/imgix/imgix.js/tree/2.2.3) and [API reference](https://github.com/imgix/imgix.js/blob/2.2.3/docs/api.md).**
-
-**Note:** If a Javascript library for generating imgix URLs is desired, consider using [imgix-core-js](https://github.com/imgix/imgix-core-js) instead.
-
 `imgix.js` allows developers to easily generate responsive images using the `srcset` and `sizes` attributes, or the `picture` element. This lets you write a single image URL that is parsed and used to make images look great at any screen size, by using [imgix](https://imgix.com) to process and resize your images on the fly.
+
+**Note:** imgix.js is designed to run in the browser, manipulating existing `<img>` elements on an HTML page. If you're looking for a JavaScript library that can programmatically generate imgix URLs, consider using [imgix-core-js](https://github.com/imgix/imgix-core-js) instead.
 
 **Before getting started with imgix.js**, it is _highly recommended_ that you read Eric Portis' [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/). This article explains the history of responsive images in responsive design, why they're necessary, and how all these technologies work together to save bandwidth and provide a better experience for users. The primary goal of `imgix.js` is to make these tools easier for developers to implement, so having an understanding of how they work will significantly improve your `imgix.js` experience.
 

--- a/README.md
+++ b/README.md
@@ -1,53 +1,59 @@
-![imgix logo](https://assets.imgix.net/imgix-logo-web-2014.pdf?page=2&fm=png&w=120)
+<!-- ix-docs-ignore -->
+![imgix logo](https://assets.imgix.net/sdk-imgix-logo.svg)
 
-# imgix.js [![Build Status](https://travis-ci.org/imgix/imgix.js.svg?branch=master)](https://travis-ci.org/imgix/imgix.js)
+`imgix.js` is a dependency-free JavaScript library for the browser that allows for easy integration of [imgix](https://www.imgix.com) into websites.
 
-**This documentation is for imgix.js version `3.0.0` and up. Those using imgix.js `2.x.x` can find documentation in that version's [readme](https://github.com/imgix/imgix.js/tree/2.2.3) and [API reference](https://github.com/imgix/imgix.js/blob/2.2.3/docs/api.md).**
+[![NPM Version](https://img.shields.io/npm/v/imgix.js.svg)](https://www.npmjs.com/package/imgix.js)
+[![Build Status](https://travis-ci.org/imgix/imgix.js.svg?branch=master)](https://travis-ci.org/imgix/imgix.js)
+[![Monthly Downloads](https://img.shields.io/npm/dm/imgix.js.svg)](https://www.npmjs.com/package/imgix.js)
+[![Minified Size](https://img.shields.io/bundlephobia/min/imgix.js)](https://bundlephobia.com/result?p=imgix.js)
+[![License](https://img.shields.io/github/license/imgix/imgix.js)](https://github.com/imgix/imgix.js/blob/master/LICENSE.md)
+[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
-**Note:** If you're looking for a Javascript library just to generate imgix URLs, check out [imgix-core-js](https://github.com/imgix/imgix-core-js).
+---
+<!-- /ix-docs-ignore -->
 
-
-imgix.js allows developers to easily generate responsive images using the `srcset` and `sizes` attributes, or the `picture` element. This lets you write a single image URL that is parsed and used to make images look great at any screen size, by using [imgix](https://imgix.com) to process and resize your images on the fly.
-
-Responsive images in the browser, simplified. Pure JavaScript with zero dependencies. About 2 KB minified and gzipped.
-
-* [Overview / Resources](#overview-and-resources)
-* [Installation](#installation)
-* [Configuration](#configuration)
-* [Usage](#usage)
-  * [`ix-src`](#ix-src)
-  * [`ix-path` and `ix-params`](#ix-path-and-ix-params)
-  * [`picture` tags](#picture-tags)
-* [Advanced Usage](#advanced-usage)
-  * [Overriding `ix-host`](#overriding-ix-host)
-  * [Disabling auto-initialization](#disabling-auto-initialization)
-  * [Manually initializing imgix.js](#manually-initializing-imgix-js)
-  * [`imgix.init()` idempotency](#imgix-init-idempotency)
-  * [Lazy loading With lazysizes](#lazy-loading-with-lazysizes)
-  * [Custom input attributes](#custom-input-attributes)
-  * [Null output attributes](#null-output-attributes)
-  * [Base-64 encoded parameters](#base-64-encoded-parameters)
-  * [Default Parameters](#default-parameters)
-  * [What is the `ixlib` param?](#what-is-the-ixlib-param)
-* [Browser Support](#browser-support)
-* [Meta](#meta)
-
+- [Overview / Resources](#overview--resources)
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Usage](#usage)
+  - [ix-src](#ix-src)
+  - [ix-path and ix-params](#ix-path-and-ix-params)
+  - [picture tags](#picture-tags)
+- [Advanced Usage](#advanced-usage)
+  - [Overriding ix-host](#overriding-ix-host)
+  - [Disabling auto-initialization](#disabling-auto-initialization)
+  - [Manually initializing imgix.js](#manually-initializing-imgixjs)
+  - [imgix.init() idempotency](#imgixinit-idempotency)
+  - [Lazy Loading With lazysizes](#lazy-loading-with-lazysizes)
+  - [Custom Input Attributes](#custom-input-attributes)
+  - [Null Output Attributes](#null-output-attributes)
+  - [Base-64 encoded parameters](#base-64-encoded-parameters)
+  - [Default parameters](#default-parameters)
+  - [What is the ixlib param?](#what-is-the-ixlib-param)
+- [Browser Support](#browser-support)
+- [Meta](#meta)
 
 <a name="overview-and-resources"></a>
 ## Overview / Resources
 
-**Before you get started with imgix.js**, it's _highly recommended_ that you read Eric Portis' [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/). This article explains the history of responsive images in responsive design, why they're necessary, and how all these technologies work together to save bandwidth and provide a better experience for users. The primary goal of imgix.js is to make these tools easier for developers to implement, so having an understanding of how they work will significantly improve your imgix.js experience.
+**This documentation is for imgix.js version `3.0.0` and up. Those using imgix.js `2.x.x` can find documentation in the corresponding version's [readme](https://github.com/imgix/imgix.js/tree/2.2.3) and [API reference](https://github.com/imgix/imgix.js/blob/2.2.3/docs/api.md).**
+
+**Note:** If a Javascript library for generating imgix URLs is desired, consider using [imgix-core-js](https://github.com/imgix/imgix-core-js) instead.
+
+`imgix.js` allows developers to easily generate responsive images using the `srcset` and `sizes` attributes, or the `picture` element. This lets you write a single image URL that is parsed and used to make images look great at any screen size, by using [imgix](https://imgix.com) to process and resize your images on the fly.
+
+**Before getting started with imgix.js**, it is _highly recommended_ that you read Eric Portis' [seminal article on `srcset` and `sizes`](https://ericportis.com/posts/2014/srcset-sizes/). This article explains the history of responsive images in responsive design, why they're necessary, and how all these technologies work together to save bandwidth and provide a better experience for users. The primary goal of `imgix.js` is to make these tools easier for developers to implement, so having an understanding of how they work will significantly improve your `imgix.js` experience.
 
 Below are some other articles that help explain responsive imagery, and how it can work alongside imgix:
 
-* [Using imgix with `<picture>`](https://docs.imgix.com/tutorials/using-imgix-picture-element). Discusses the differences between art direction and resolution switching, and provides examples of how to accomplish art direction with imgix.
-* [Responsive Images with `srcset` and imgix](https://docs.imgix.com/tutorials/responsive-images-srcset-imgix). A look into how imgix can work with `srcset` and `sizes` to serve the right image.
-
+- [Using imgix with `<picture>`](https://docs.imgix.com/tutorials/using-imgix-picture-element). Discusses the differences between art direction and resolution switching, and provides examples of how to accomplish art direction with imgix.
+- [Responsive Images with `srcset` and imgix](https://docs.imgix.com/tutorials/responsive-images-srcset-imgix). A look into how imgix can work with `srcset` and `sizes` to serve the right image.
 
 <a name="installation"></a>
 ## Installation
 
-There are several ways to install imgix.js. The appropriate method depends on your project.
+There are several ways to install `imgix.js`. The appropriate method depends on your project.
 
 1. **npm**: `npm install --save imgix.js`
 2. **Bower**: `bower install --save imgix.js`
@@ -55,16 +61,15 @@ There are several ways to install imgix.js. The appropriate method depends on yo
 
 If your build process will re-run `dist/imgix.js` or `dist/imgix.min.js` through Browserify, you'll need to add `noParse: [require.resolve('imgix.js')]` to your Browserify config. If you skip this, Browserify will attempt to re-require imgix.js' dependencies, which have already been inlined.
 
-After you've included imgix.js on your page, it will automatically run once, after the `DOMContentLoaded` event fires. This will detect and process all `img` and `source` tags on the page that are set up to use imgix.js as described in the [Usage](#usage) section of this README.
-
+Once `imgix.js` has been included on the page, it will automatically run once, after the `DOMContentLoaded` event fires. This will detect and process all `img`, `picture`, and `source` tags on the page that are set up to use `imgix.js` as described in the [Usage](#usage) section of this README.
 
 <a name="configuration"></a>
 ## Configuration
 
-imgix.js has two important global options:
+`imgix.js` has two important global options:
 
-* `host`: Your imgix hostname (defaults to `null`). This enables the use of `ix-path` and `ix-params` to define images, instead of having to manually type URLs out in `ix-src`. See the [`ix-path` and `ix-params`](#ix-path-and-ix-params) section below for details.
-* `useHttps`: A boolean (defaults to `true`), specifying whether to generate `http` or `https`-prefixed URLs.
+- `host`: A string corresponding to the desired imgix hostname (defaults to `null`). This enables the use of `ix-path` and `ix-params` to define images, instead of having to manually provide URLs out in `ix-src`. See the [`ix-path` and `ix-params`](#ix-path-and-ix-params) section below for details.
+- `useHttps`: A boolean (defaults to `true`), specifying whether to generate `http` or `https`-prefixed URLs.
 
 These configuration options (as well as other options described in the ["Advanced Usage" section](#advanced-usage)) can be defined in two ways. The easiest way is to specify them with `meta` tags in your document's `<head>`:
 
@@ -88,12 +93,12 @@ The other way is to manually set these options on the `imgix.config` object. Not
 <a name="usage"></a>
 ## Usage
 
-Now that everything's installed and set up, you can start adding responsive images to the page. There are a few ways to do this.
+After installation and set up are complete, one can begin adding responsive images to the page through one of few ways:
 
 <a name="ix-src"></a>
 ### `ix-src`
 
-The simplest way to use imgix.js is to create an `img` tag with the `ix-src` attribute:
+Creates an `img` tag with the `ix-src` attribute:
 
 ``` html
 <img
@@ -123,19 +128,18 @@ This will generate HTML something like the following:
 >
 ```
 
-Since imgix can generate as many derivative resolutions as needed, imgix.js calculates them programmatically, using the dimensions you specify (note that the `w` and `h` params scale appropriately to maintain the correct aspect ratio). All of this information has been placed into the `srcset` and `sizes` attributes. Because of this, imgix.js no longer needs to watch or change the `img` tag, as all responsiveness will be handled automatically by the browser as the page is resized.
-
+Since imgix can generate as many derivative resolutions as needed, `imgix.js` calculates them programmatically, using the dimensions you specify (note that the `w` and `h` params scale appropriately to maintain the correct aspect ratio). All of this information has been placed into the `srcset` and `sizes` attributes. Because of this, imgix.js no longer needs to watch or change the `img` tag, as all responsiveness will be handled automatically by the browser as the page is resized.
 
 <a name="ix-path-and-ix-params"></a>
 ### `ix-path` and `ix-params`
 
-If you've [configured imgix.js](#configuration) with a global `host` option, you can use the `ix-path` and `ix-params` attributes instead of `ix-src`. The `ix-path` attribute is used to specify the path to your image, and the `ix-params` attribute is used to define the [ imgix URL API parameters](https://docs.imgix.com/apis/url) you'd like to apply to your image. Using these two attributes instead of `ix-src` has several advantages:
+If [configured](#configuration) with a global `host` option, `imgix.js` can use the `ix-path` and `ix-params` attributes instead of `ix-src`. The `ix-path` attribute is used to specify the path to an image, and the `ix-params` attribute is used to define the [imgix URL API parameters](https://docs.imgix.com/apis/url) to be applied to the image. Using these two attributes instead of `ix-src` has several advantages:
 
-  1. `ix-params` automatically URL/Base64-encodes your specified parameters, [as appropriate](#base-64-encoded-parameters).
+  1. `ix-params` automatically URL/Base64-encodes specified parameters, [as appropriate](#base-64-encoded-parameters).
   2. `ix-params` is a JSON string, which is easier to read than a URL and can be generated by other tools if necessary.
-  3. Not having to re-type `https://my-source.imgix.net` helps keep your code DRY.
+  3. Not having to re-type `https://my-source.imgix.net` helps keep code DRY.
 
-Here's how the previous example would be written out using `ix-path` and `ix-params` instead of `ix-src`. Regardless of which method you choose, the end result in-browser will be the same.
+Here's how the previous example would be written out using `ix-path` and `ix-params` instead of `ix-src`. Regardless of the method choosen, the end result in-browser will be the same.
 
 ``` html
 <img
@@ -155,7 +159,7 @@ Here's how the previous example would be written out using `ix-path` and `ix-par
 <a name="picture-tags"></a>
 ### `picture` tags
 
-If you need art-directed images, imgix.js plays nicely with the `picture` tag. This allows you to specify more advanced responsive images, by changing things such as the crop and aspect ratio for different screens. To get started, just construct a `picture` tag with a `source` attribute for each art-directed image, and a fallback `img` tag. If you're new to using the `picture` tag, you might want to check out our [tutorial](https://docs.imgix.com/tutorials/using-imgix-picture-element) to learn how it works.
+If an art-directed image is desired, `imgix.js` plays nicely with the `picture` tag. This allows for specifying more advanced responsive images, by changing properties such as the crop and aspect ratio for different screens. To get started, construct a `picture` tag with a `source` attribute for each art-directed image, and a fallback `img` tag. If new to using the `picture` tag, consider reading our [tutorial](https://docs.imgix.com/tutorials/using-imgix-picture-element) to learn more about how it works.
 
 The `source` tags can be used with `ix-src` or `ix-path` and `ix-params`, just like `img` tags. The following example will generate HTML that displays Bert _and_ Ernie on small screens, just Bert on medium-sized screens, and just Ernie on large screens.
 
@@ -202,7 +206,7 @@ The `source` tags can be used with `ix-src` or `ix-path` and `ix-params`, just l
 <a name="overriding-ix-host"></a>
 ### Overriding `ix-host`
 
-If you need to display images from multiple imgix Sources, the `host` option can be overridden on any `img` or `source` tag by specifying an `ix-host` attribute in the tag:
+When displaying images between multiple imgix Sources, the `host` option can be overridden on any `img` or `source` tag by specifying an `ix-host` attribute in the tag:
 
 ``` html
 <img
@@ -221,7 +225,7 @@ If you need to display images from multiple imgix Sources, the `host` option can
 <a name="disabling-auto-initialization"></a>
 ### Disabling auto-initialization
 
-By default, imgix.js will automatically run as soon as the `DOMContentLoaded` event fires, immediately processing all `img` and `source` tags on the page that are set up to use imgix.js. You can disable this auto-initialization behavior by including the following `meta` tag in your document's `head`:
+By default, `imgix.js` will automatically run as soon as the `DOMContentLoaded` event fires, immediately processing all `img` and `source` tags on the page that are set up to use `imgix.js`. This auto-initialization behavior can be disabled by including the following `meta` tag in the document's `head`:
 
 ``` html
 <head>
@@ -232,9 +236,9 @@ By default, imgix.js will automatically run as soon as the `DOMContentLoaded` ev
 <a name="manually-initializing-imgix-js"></a>
 ### Manually initializing imgix.js
 
-If you disable auto-initialization as [described above](#disabling-auto-initialization), you'll need to manually run imgix.js in order to process the `img` and `source` tags on the page. You can do so by simply calling `imgix.init()`.
+If auto-initialization is disabled as [described above](#disabling-auto-initialization), `imgix.js` will need to be run manually in order to process the `img` and `source` tags on the page. This can be done by invoking `imgix.init()`.
 
-When calling `imgix.init()`, you can also pass in a map of options to override the global configuration settings. For example:
+When calling `imgix.init()`, a map of options can be passed in to override the global configuration settings. For example:
 
 ``` js
 imgix.init({
@@ -259,7 +263,7 @@ imgix.init({
 <a name="lazy-loading-with-lazysizes"></a>
 ### Lazy Loading With [lazysizes](https://github.com/aFarkas/lazysizes)
 
-If you'd like to lazy load images, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use imgix.js with lazysizes, you can simply tell it to generate lazysizes-compatible attributes instead of the standard `src`, `srcset`, and `sizes` by changing some configuration settings:
+If lazy loading images is desired, we recommend using [lazysizes](https://github.com/aFarkas/lazysizes). In order to use `imgix.js` with lazysizes, generate images using lazysizes-compatible attributes instead of the standard `src`, `srcset`, and `sizes` by changing some configuration settings:
 
 Using `<meta>` tags:
 
@@ -282,7 +286,7 @@ imgix.config.sizesAttribute = 'data-sizes';
 <a name="custom-input-attributes"></a>
 ### Custom Input Attributes
 
-imgix.js defaults to pulling its data from the `ix-src`, `ix-path`, `ix-params`, and `ix-host` attributes. If you'd like to use custom input attributes, you can specify them by changing some configuration settings. This can be useful if you're concerned about W3C compliance.
+`imgix.js` defaults to pulling its data from the `ix-src`, `ix-path`, `ix-params`, and `ix-host` attributes. If custom input attributes are desired, they can be specified by changing some configuration settings. This can be useful if, say, there is a concern about W3C compliance.
 
 Using `<meta>` tags:
 
@@ -307,7 +311,7 @@ imgix.config.hostInputAttribute = 'data-ix-host';
 <a name="null-output-attributes"></a>
 ### Null Output Attributes
 
-In rare cases, it may be undesirable to have imgix.js modify the `src`, `srcset`, or `sizes` attributes of the `<img>` elements it's targeting. In such cases, you can override the default behavior by setting some configuration values to null:
+In rare cases, it may be undesirable to have `imgix.js` modify the `src`, `srcset`, or `sizes` attributes of the `<img>` elements it's targeting. In such cases, the default behavior can be overriden by setting some configuration values to `null`:
 
 Using `<meta>` tags:
 
@@ -332,7 +336,7 @@ imgix.config.sizesAttribute = null;
 
 All of imgix's API parameters can be provided as [Base64 variants](https://docs.imgix.com/apis/url#base64-variants). This is especially useful when providing text for the `txt` parameter, or URLs for parameters such as `mark` or `blend`.
 
-When providing parameters to imgix.js via the `ix-params` attribute, note that the values for any Base64 variant parameters will be automatically base64-encoded by imgix.js, and can therefore be provided *unencoded*.
+When providing parameters via the `ix-params` attribute, note that the values for any Base64 variant parameters will be automatically base64-encoded by `imgix.js`, and can therefore be provided *unencoded*.
 
 ``` html
 <img
@@ -344,7 +348,7 @@ When providing parameters to imgix.js via the `ix-params` attribute, note that t
 >
 ```
 
-When providing a URL with parameters to imgix.js via the `ix-src` attribute, note that the values for any Base64 variant parameters will *not* be automatically base64-encoded by imgix.js.
+When providing a URL with parameters via the `ix-src` attribute, note that the values for any Base64 variant parameters will *not* be automatically base64-encoded by `imgix.js`.
 
 ``` html
 <img
@@ -357,7 +361,7 @@ When providing a URL with parameters to imgix.js via the `ix-src` attribute, not
 <a name="default-parameters"></a>
 ### Default parameters
 
-If the same parameters are being used again and again, they can be extracted out into a global config using `imgix.defaultParameters`. These settings will become the default paramters for each imgix tag globally, before any specific params are loaded from `ix-params` or `ix-src`
+If a default set of parameters are desired, they can be extracted out into a global config using `imgix.defaultParameters`. These settings will become the default paramters for each imgix tag globally, before any specific parameters are loaded from `ix-params` or `ix-src`
 
 ```js
 // setup
@@ -400,10 +404,10 @@ imgix.config.includeLibraryParam = false;
 <a name="browser-support"></a>
 ## Browser Support
 
-* By default, browsers that don't support [`srcset`](http://caniuse.com/#feat=srcset), [`sizes`](http://caniuse.com/#feat=srcset), or [`picture`](http://caniuse.com/#feat=picture) will gracefully fall back to the default `img` `src` when appropriate. If you want to provide a fully-responsive experience for these browsers, imgix.js works great alongside [Picturefill](https://github.com/scottjehl/picturefill)!
-* If you are using [Base64 variant params](https://docs.imgix.com/apis/url#base64-variants) and need IE <= 9 support, we recommend using a polyfill for `atob`/`btoa`, such as [Base64.js](https://github.com/davidchambers/Base64.js).
+- By default, browsers that don't support [`srcset`](http://caniuse.com/#feat=srcset), [`sizes`](http://caniuse.com/#feat=srcset), or [`picture`](http://caniuse.com/#feat=picture) will gracefully fall back to the default `img` `src` when appropriate. If you want to provide a fully-responsive experience for these browsers, `imgix.js` works great alongside [Picturefill](https://github.com/scottjehl/picturefill)!
+- If using [Base64 variant params](https://docs.imgix.com/apis/url#base64-variants) and require IE <= 9 support, we recommend using a polyfill for `atob`/`btoa`, such as [Base64.js](https://github.com/davidchambers/Base64.js).
 
 <a name="meta"></a>
 ## Meta
 
-imgix.js was made by [imgix](http://imgix.com). It's licensed under the BSD 2-Clause license (see the [license file](https://github.com/imgix/imgix.js/blob/master/LICENSE.md) for more info). Any contribution is absolutely welcome, but please review the [contribution guidelines](https://github.com/imgix/imgix.js/blob/master/CONTRIBUTING.md) before getting started.
+`imgix.js` was made by [imgix](http://imgix.com). It's licensed under the BSD 2-Clause license (see the [license file](https://github.com/imgix/imgix.js/blob/master/LICENSE.md) for more info). Any contribution is absolutely welcome, but please review the [contribution guidelines](https://github.com/imgix/imgix.js/blob/master/CONTRIBUTING.md) before getting started.


### PR DESCRIPTION
This PR restructures the header section of the README, adds more badges, and makes some edits to content and writing style. The header is wrapped in a tag that will exclude it from being displayed on the [imgix libraries](https://docs.imgix.com/libraries) page.

<img width="926" alt="imgix js-readme" src="https://user-images.githubusercontent.com/15919091/71705950-06374180-2db0-11ea-951b-b4675f86958c.png">
