### PR TITLE
chore: replace ref to master with main

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ addons:
 
 branches:
   only:
-    - master
+    - main
     - /release.*/


### PR DESCRIPTION
Follow up to #221, replaces a missed reference to `master`