### PR TITLE
ci: update supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'stable'
+  - stable
 install:
   - npm install
 script:


### PR DESCRIPTION
Adds [currently supported](https://nodejs.org/en/about/releases/) LTS node versions to CI.