### PR TITLE
docs: fix TOC for lazyloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
     * [Disabling auto-initialization](#disabling-auto-initialization)
     * [Manually initializing imgix.js](#manually-initializing-imgixjs)
     * [`imgix.init()` idempotency](#imgixinit-idempotency)
-    * [Lazy Loading With [lazysizes](https://github.com/aFarkas/lazysizes)](#lazy-loading-with-lazysizeshttpsgithubcomafarkaslazysizes)
+    * [Lazy Loading With lazysizes](#lazy-loading-with-lazysizeshttpsgithubcomafarkaslazysizes)
     * [Custom Input Attributes](#custom-input-attributes)
     * [Null Output Attributes](#null-output-attributes)
     * [Base-64 encoded parameters](#base-64-encoded-parameters)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
     * [Disabling auto-initialization](#disabling-auto-initialization)
     * [Manually initializing imgix.js](#manually-initializing-imgixjs)
     * [`imgix.init()` idempotency](#imgixinit-idempotency)
-    * [Lazy Loading With lazysizes](#lazy-loading-with-lazysizeshttpsgithubcomafarkaslazysizes)
+    * [Lazy Loading With lazysizes](#https://github.com/imgix/imgix.js#lazy-loading-with-lazysizes)
     * [Custom Input Attributes](#custom-input-attributes)
     * [Null Output Attributes](#null-output-attributes)
     * [Base-64 encoded parameters](#base-64-encoded-parameters)


### PR DESCRIPTION
Github doesn't parse nested links correctly, so I removed the nested link for the "lazyloading" TOC header

# Description

The TOC header was broken cause of a nested link. This PR removes the nested link:
![image](https://user-images.githubusercontent.com/22304763/115906219-f0b1b500-a402-11eb-8677-b8de7709589a.png)


## Checklist: Fixing typos/Doc change

- [x] Each commit follows the [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/#summary) format: e.g. `chore(readme): fixed typo`. See the end of this file for more information.

## Steps to Test

<!-- Delete this selction if you are just submitting a doc change/small fix -->

<!-- A code example or a set of steps is preferred -->

Related issue: [e.g. #42]

Code:

```js
// A standalone example of what the PR solves
```

<!-- A link to a codepen/codesandbox is also an option. -->

<!--

## Conventional Commit Spec

PR titles should be in the format `<type>(<scope>): <description>`. For example: `chore(readme): fix typo`

`type` can be any of the follow:
  - `feat`: a feature, or breaking change
  - `fix`: a bug-fix
  - `test`: Adding missing tests or correcting existing tests
  - `docs`: documentation only changes (readme, changelog, contributing guide)
  - `refactor`: a code change that neither fixes a bug nor adds a feature
  - `chore`: reoccurring tasks for project maintainability (example scopes: release, deps)
  - `config`: changes to tooling configurations used in the project
  - `build`: changes that affect the build system or external dependencies (example scopes: npm, bundler, gradle)
  - `ci`: changes to CI configuration files and scripts (example scopes: travis)
  - `perf`: a code change that improves performance
  - `style`: changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)

`scope` is optional, and can be anything.
`description` should be a short description of the change, written in the imperative-mood.
-->
