### PR TITLE
chore(debounce): add debounce fn and refactor raf

### DIFF
--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -34,45 +34,6 @@ describe('When a page gets resized', () => {
       assert.isAtLeast(imgSize, expectedSize);
     });
   });
-
-  it('Stores previous measured width value if window is resized', () => {
-    cy.get('[data-test-id="sizes"]', { timeout: 300 }).each(($el) => {
-      const imgOffsetWidth = $el.attr('_ixWidth');
-      // _ixWidth helps us avoid setting the sizes attr if
-      // its already been updated to the current value. Ie
-      // if _ixWidth == 40px and offsetWidth == 40px, don't
-      // overwrite sizes attr, already been done at this width.
-      expect(imgOffsetWidth).to.exist;
-    });
-  });
-
-  it('Tracks the status of the resize event listener', () => {
-    cy.get('[data-test-id="sizes"]').each(($el) => {
-      const listenerStatus = $el.attr('_ixListening');
-      // _ixListening tracks if event listener has been
-      // removed from the element yet or not.
-      expect(listenerStatus).to.exist;
-    });
-  });
-
-  it('Tracks call to rAF', () => {
-    cy.get('[data-test-id="sizes"]').each(($el) => {
-      const rAFId = $el.attr('_ixRaf');
-      // _ixRaf tracks the rAF id of the element
-      expect(rAFId).to.exist;
-    });
-  });
-
-  it('Cancels calls to rAF if a new call made in the same frame', () => {
-    cy.viewport(500, 900);
-    cy.get('[data-test-id="sizes"]').each(($el) => {
-      const rAFId = $el.attr('_ixRaf');
-      // _ixRaf tracks the rAF id of the element
-      expect(rAFId).to.not.equal(1);
-    });
-  });
-
-  //
 });
 
 describe('On an invalid image', () => {

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -19,11 +19,11 @@ describe('On a pages first render', () => {
 describe('When a page gets resized', () => {
   before(() => {
     cy.visit('/cypress/fixtures/samplePage.html');
+    cy.viewport(500, 500);
   });
 
   beforeEach(() => {
     cy.fixture('config.js').as('config');
-    cy.viewport(500, 500);
   });
 
   it('Updates the sizes attribute on resize', () => {
@@ -35,31 +35,37 @@ describe('When a page gets resized', () => {
     });
   });
 
-  it(`Check resize waits for debounce`, () => {
-    // resize browser to x
-    // check sizes hasn't changed to x
-    // resize browser to y
-    // check sizes hasn't changed to x
-    // wait 200ms
-    // check sizes has changed to y
-    cy.visit('/cypress/fixtures/samplePage.html');
-    cy.viewport(500, 500);
-    cy.get('[data-test-id="sizes"]')
-      .first()
-      .then(($el) => {
-        // const expectedSize = Math.ceil($el.width());
-        const imgSize = Number($el.attr('sizes').split('px')[0]);
-        assert.isAtMost(imgSize, 500);
-        cy.viewport(1000, 500);
-        cy.wait(10);
-        // check sizes HASN'T changed
-        cy.viewport(1500, 500);
-        cy.wait(200);
-        // check sizes HAS changed
-        const newImageSize = Number($el.attr('sizes').split('px')[0]);
-        expect(newImageSize).to.not.equal(imgSize);
-        // assert.isAtLeast(imgSize, expectedSize);
-      });
+  context('When multiple resizes happen', () => {
+    it(`Does not update size before debounce is finished`, () => {
+      cy.get('[data-test-id="sizes"]')
+        .first()
+        .then(($el) => {
+          // store and check the image size before resize
+          let imgSize = Number($el.attr('sizes').split('px')[0]);
+          const expectedSize = Math.ceil($el.width());
+          assert.isAtMost(imgSize, 500);
+          // resize and wait only 10ms
+          cy.viewport(1000, 500);
+          cy.wait(10);
+          // check sizes has NOT changed
+          imgSize = Number($el.attr('sizes').split('px')[0]);
+          assert.isAtMost(imgSize, 500);
+          assert.isAtLeast(imgSize, expectedSize);
+        });
+    });
+    it('Updates size after debounce has finished', () => {
+      cy.viewport(1500, 500);
+      cy.wait(300);
+      cy.get('[data-test-id="sizes"]')
+        .first()
+        .then(($el) => {
+          // check sizes HAS changed
+          const newImgSize = Number($el.attr('sizes').split('px')[0]);
+          assert.isAtLeast(newImgSize, 500);
+          assert.isAtMost(newImgSize, 1500);
+          expect(newImgSize).to.not.equal(404);
+        });
+    });
   });
 });
 

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -34,6 +34,33 @@ describe('When a page gets resized', () => {
       assert.isAtLeast(imgSize, expectedSize);
     });
   });
+
+  it(`Check resize waits for debounce`, () => {
+    // resize browser to x
+    // check sizes hasn't changed to x
+    // resize browser to y
+    // check sizes hasn't changed to x
+    // wait 200ms
+    // check sizes has changed to y
+    cy.visit('/cypress/fixtures/samplePage.html');
+    cy.viewport(500, 500);
+    cy.get('[data-test-id="sizes"]')
+      .first()
+      .then(($el) => {
+        // const expectedSize = Math.ceil($el.width());
+        const imgSize = Number($el.attr('sizes').split('px')[0]);
+        assert.isAtMost(imgSize, 500);
+        cy.viewport(1000, 500);
+        cy.wait(10);
+        // check sizes HASN'T changed
+        cy.viewport(1500, 500);
+        cy.wait(200);
+        // check sizes HAS changed
+        const newImageSize = Number($el.attr('sizes').split('px')[0]);
+        expect(newImageSize).to.not.equal(imgSize);
+        // assert.isAtLeast(imgSize, expectedSize);
+      });
+  });
 });
 
 describe('On an invalid image', () => {

--- a/src/util.js
+++ b/src/util.js
@@ -102,4 +102,38 @@ module.exports = {
       return metaTagContent;
     }
   },
+  debounce: function (func, waitMs) {
+    // based off: http://modernjavascript.blogspot.com/2013/08/building-better-debounce.html
+    // we need to save these in the closure
+    var timeout, args, context, timestamp;
+
+    return function () {
+      // save details of latest call
+      context = this;
+      args = [].slice.call(arguments, 0);
+      timestamp = new Date();
+
+      // this is where the magic happens
+      var later = function () {
+        // how long ago was the last call
+        var timeSinceLastCallMs = new Date() - timestamp;
+
+        // if the latest call was less that the wait period ago
+        // then we reset the timeout to wait for the difference
+        if (timeSinceLastCallMs < waitMs) {
+          timeout = setTimeout(later, waitMs - timeSinceLastCallMs);
+
+          // or if not we can null out the timer and run the latest
+        } else {
+          timeout = null;
+          func.apply(context, args);
+        }
+      };
+
+      // we only need to set the timer now if one isn't already running
+      if (!timeout) {
+        timeout = setTimeout(later, waitMs);
+      }
+    };
+  },
 };


### PR DESCRIPTION
# Description
This PR creates a debounce fn that better limits the amount updates to the `sizes` attribute made by `updateOnResize()`. It also removes custom attributes that are no longer needed, like `_ixWidth`.

The PR also adds tests cases to ensure the module waits for the debounce before updating the `sizes` attribute.