### PR TITLE
chore(debounce): use lodash debounce package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "version": "3.4.2",
       "license": "BSD-2-Clause",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8"
+      },
       "devDependencies": {
         "atob": "2.1.2",
         "browserify": "17.0.0",
@@ -7244,8 +7247,7 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "node_modules/lodash.get": {
       "version": "4.4.2",
@@ -18582,8 +18584,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
-      "dev": true
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "lodash.get": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
     "sinon": "10.0.0",
     "standard-version": "9.2.0",
     "uglify-js": "3.13.5"
+  },
+  "dependencies": {
+    "lodash.debounce": "^4.0.8"
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,5 @@
+const _debounce = require('lodash.debounce');
+
 module.exports = {
   compact: function (arr) {
     var compactedArr = [];
@@ -102,40 +104,7 @@ module.exports = {
       return metaTagContent;
     }
   },
-  debounce: function (func, waitMs) {
-    // based off: http://modernjavascript.blogspot.com/2013/08/building-better-debounce.html
-    // we need to save these in the closure
-    var timeout, args, context, timestamp;
-
-    return function () {
-      // save details of latest call
-      context = this;
-      args = [].slice.call(arguments, 0);
-      timestamp = new Date();
-
-      // this is where the magic happens
-      var later = function () {
-        // how long ago was the last call
-        var timeSinceLastCallMs = new Date() - timestamp;
-
-        // if the latest call was less that the wait period ago
-        // then we reset the timeout to wait for the difference
-        if (timeSinceLastCallMs < waitMs) {
-          timeout = setTimeout(later, waitMs - timeSinceLastCallMs);
-
-          // or if not we can null out the timer and run the latest
-        } else {
-          timeout = null;
-          func.apply(context, args);
-        }
-      };
-
-      // we only need to set the timer now if one isn't already running
-      if (!timeout) {
-        timeout = setTimeout(later, waitMs);
-      }
-    };
-  },
+  debounce: _debounce,
   rICShim: function (_window) {
     // from: https://developers.google.com/web/updates/2015/08/using-requestidlecallback#checking_for_requestidlecallback
     return (


### PR DESCRIPTION
This PR replaces the custom `debounce` function with [lodash's](https://lodash.com/docs/4.17.15#debounce) `_.debounce`.

This reduces our need to keep  the function up to date with the best practices around debouncing and introduces new functionality (leading vs trailing debouncing) that we can leverage.