### PR TITLE
build: limit which files are publish in a release

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,9 @@
   },
   "dependencies": {
     "lodash.debounce": "^4.0.8"
-  }
+  },
+  "files": [
+    "dist",
+    "src"
+  ]
 }


### PR DESCRIPTION
I noticed in a previous release that we are not restricting which files/directories get published. This results in several non-essential files getting bundled in the release, which causes bloat for our end users. This PR fixes this issue by requiring files/directories to be opted in via the package.json [files](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files) field. In this way, maintainers don't have to remember to update an opt-out list (such as `.gitignore`) when working on this library.

Note:
> Certain files are always included, regardless of settings:
>   package.json
	README
    CHANGES / CHANGELOG / HISTORY
    LICENSE / LICENCE
    NOTICE
    The file in the "main" field
>
> README, CHANGES, LICENSE & NOTICE can have any case and extension.

Note 2: if you're ever unsure, you can always test the potential bundle contents of a release by running `npm pack`.