### PR TITLE
fix(getSize): calc app size if parent elem has columns

### DIFF
--- a/index.css
+++ b/index.css
@@ -15,16 +15,13 @@ article figure img {
 #photos-grid {
   /* Prevent vertical gaps */
   line-height: 0;
-  -moz-column-count: 5;
-  -moz-column-gap: 0px;
   column-count: 5;
   column-gap: 0px;
 }
 
-#photos-grid img {
-  /* Just in case there are inline attributes */
-  width: 100% !important;
-  height: auto !important;
+.photo-grid-container {
+  width: 100%;
+  height: auto;
 }
 
 .size-info {

--- a/index.html
+++ b/index.html
@@ -167,6 +167,15 @@
           affect performance.
         </p>
         <div id="photos-grid">
+          <div class="photo-grid-container">
+            <img
+            data-test-id="sizes-grid"
+            alt="img-grid-img"
+            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+            test-params="{}"
+            sizes="auto"
+          />
+          </div>
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
@@ -181,20 +190,15 @@
             test-params="{}"
             sizes="auto"
           />
-          <img
-            data-test-id="sizes-grid"
-            alt="img-grid-img"
-            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
-            test-params="{}"
-            sizes="auto"
-          />
-          <img
-            data-test-id="sizes-grid"
-            alt="img-grid-img"
-            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
-            test-params="{}"
-            sizes="auto"
-          />
+          <section>
+            <img
+              data-test-id="sizes-grid"
+              alt="img-grid-img"
+              test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+              test-params="{}"
+              sizes="auto"
+            />
+        </section>
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"

--- a/index.js
+++ b/index.js
@@ -1,7 +1,5 @@
 const images = document.querySelectorAll('#photos-grid img');
 
-console.log(images);
-
 images.forEach((img) => {
   const newDiv = document.createElement('div');
   const newP = document.createElement('p');
@@ -10,7 +8,6 @@ images.forEach((img) => {
   newP.textContent = 'sizes=' + size;
   newDiv.appendChild(newP);
   img.insertAdjacentElement('afterend', newDiv);
-  console.log(img, newDiv);
 });
 
 setInterval(() => {

--- a/src/autoSize.js
+++ b/src/autoSize.js
@@ -68,7 +68,7 @@ const getWidth = function ({ parent, width, _window }) {
 
   const parentColumnCount = getParentColumnCount({ _window, parent });
 
-  return width / parentColumnCount;
+  return Math.floor(width / parentColumnCount);
 };
 
 // Based off of: https://stackoverflow.com/questions/1977871/check-if-an-image-is-loaded-no-errors-with-jquery

--- a/src/autoSize.js
+++ b/src/autoSize.js
@@ -3,7 +3,7 @@ const util = require('./util');
 const WIDTH_MIN_SIZE = 40;
 const DEBOUNCE_TIMEOUT = 200;
 
-const getParentColumnCount = ({ _window, parent, width }) => {
+const getParentColumnCount = ({ _window, parent }) => {
   /**
    *
    * In order to avoid always setting `size` to the same value as the view-width,
@@ -26,21 +26,19 @@ const getParentColumnCount = ({ _window, parent, width }) => {
    */
 
   let parentColumnCount = 1;
-  const parentStyles = _window.getComputedStyle(parent);
-  const [columnCount, gridTemplateColumns] = { ...parentStyles };
-
   const alpha = /^[A-Za-z]+$/;
 
-  if (!columnCount.value.match(alpha)) {
+  const parentStyles = _window.getComputedStyle(parent);
+  const { columnCount, gridTemplateColumns, ...rest } = { ...parentStyles };
+
+  if (columnCount && !columnCount.match(alpha)) {
     parentColumnCount = columnCount;
-  } else if (!gridTemplateColumns.value.match(alpha)) {
+  } else if (gridTemplateColumns && !gridTemplateColumns.match(alpha)) {
     if (gridTemplateColumns > parentColumnCount) {
       parentColumnCount = gridTemplateColumns;
     }
   }
-
-  // TODO(luis): should we not math.floor here? Just seems more consistent w/breakpoints
-  return Math.floor(width / parentColumnCount);
+  return parentColumnCount;
 };
 
 // If element's width is less than parent width, use the parent's. If
@@ -68,7 +66,9 @@ const getWidth = function ({ parent, width, _window }) {
     width = WIDTH_MIN_SIZE;
   }
 
-  return width;
+  const parentColumnCount = getParentColumnCount({ _window, parent });
+
+  return width / parentColumnCount;
 };
 
 // Based off of: https://stackoverflow.com/questions/1977871/check-if-an-image-is-loaded-no-errors-with-jquery


### PR DESCRIPTION
## [DRAFT][skip-ci]

In order to avoid always setting `size` to the same value as the view-width,
we need to check that the parent node is not itself divided into columns.
We can use the `getComputedStyle` to get the parent's CSS `columnCount` &
gridTemplateColumns values.

For flex-box, grid, and other layout types, these property will be populated and
describe the ideal number of columns into which the content of the element
will be flowed.

If the value is numeric, ie not the strings `auto`, `null`, etc, we can use
it to calculate the desired width:

(elementWidth / parentColumnCount) -> newWidth

Read more on column-count property here:
https://developer.mozilla.org/en-US/docs/Web/CSS/column-count
