### PR TITLE
feat(data-sizes): set sizes attribute when data-sizes set to auto

### DIFF
--- a/cypress/fixtures/index.css
+++ b/cypress/fixtures/index.css
@@ -21,10 +21,9 @@ article figure img {
   column-gap: 0px;
 }
 
-#photos-grid img {
-  /* Just in case there are inline attributes */
-  width: 100% !important;
-  height: auto !important;
+img[data-sizes='auto'] {
+  display: block;
+  width: 100%;
 }
 
 /* media queries test the browser width and adjust

--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -143,7 +143,7 @@
             data-test-id="sizes"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <!-- Invalid image -->
           <img
@@ -151,7 +151,7 @@
             data-test-id="invalid-img"
             test-path="this_wont_work!.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
             width="0px"
           />
         </figure>
@@ -181,56 +181,56 @@
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
       </article>
         <div class="button-group">

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -10,6 +10,7 @@ describe('On a pages first render', () => {
     cy.get('[data-test-id="sizes"]', { timeout: 10000 }).each(($el) => {
       const expectedSize = Math.ceil($el.width());
       const imgSize = Number($el.attr('sizes').split('px')[0]);
+      cy.wait(100);
       assert.isAtMost(imgSize, 500);
       assert.isAtLeast(imgSize, expectedSize);
     });
@@ -130,7 +131,8 @@ describe('On an invalid image or an image that has not loaded', () => {
           .first()
           .then(($ele) => {
             const imgSize = Number($ele.attr('sizes').split('px')[0]);
-            assert.isAtLeast(imgSize, $ele.width());
+            const expectedSize = Number($ele.attr('width').split('px')[0]);
+            assert.isAtLeast(imgSize, expectedSize);
             assert.isAtMost(imgSize, 500);
           });
       });

--- a/index.css
+++ b/index.css
@@ -27,6 +27,11 @@ article figure img {
   height: auto !important;
 }
 
+img[data-sizes='auto'] {
+  display: block;
+  width: 100%;
+}
+
 .size-info {
   z-index: 1;
   position: relative;

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
             data-test-id="sizes"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
         </figure>
         <div class="button-group">
@@ -176,52 +176,61 @@
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+          />
+          <section>
+            <img
+              data-test-id="sizes-grid"
+              alt="img-grid-img"
+              data-sizes="auto"
+              test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+              test-params="{}"
+            />
+        </section>
+          <img
+            data-test-id="sizes-grid"
+            data-sizes="auto"
+            alt="img-grid-img"
+            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+            test-params="{}"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
-          />
-          <img
-            data-test-id="sizes-grid"
-            alt="img-grid-img"
-            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
-            test-params="{}"
-            sizes="auto"
           />
       </article>
         <div class="button-group">

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -187,13 +187,14 @@ var ImgixTag = (function () {
 
   ImgixTag.prototype.sizes = function () {
     var existingSizes = this.el.getAttribute('sizes');
+    var dataSizes = this.el.getAttribute('data-sizes');
     const el = this.el;
     const _window = this.window;
 
-    if (existingSizes && existingSizes !== 'auto') {
+    if (existingSizes && dataSizes !== 'auto') {
       return existingSizes;
-    } else if (existingSizes === 'auto') {
-      return autoSize.updateOnResize({ el, existingSizes, _window });
+    } else if (dataSizes === 'auto') {
+      return autoSize.updateOnResize({ el, existingSizes, dataSizes, _window });
     } else {
       return '100vw';
     }


### PR DESCRIPTION
## [DRAFT]

This PR modifies the auto sizing behavior so that it reacts to `data-sizes` and not `sizes`. It does this so that:

1. CSS styles can be more easily defined on images that will use the auto sizing feature

2. It is easier to differentiate between user defined sizes and library defined sizes

To do this, the PR checks for the attribute `data-sizes=auto` on an image. If present, it will run the `autoSize` module. That module in turn sets the `size` attribute to the best approximate rendered width of the image. 

It does this by either:

- a. getting the image's offsetWidth or

- b. if smaller than the minimum width, getting the image parent's offsetWidth

This implementation assumes the user makes use of either:

- i) CSS rules to define image widths or
- ii) appropriate element nesting to ensure the images always have a parent with the corresponding width property defined.

The above can almost always be achieved by adding the bellow ruleset.

```css
img[data-sizes='auto'] {
  display: block;
  width: 100%;
}
```

Alternitively, the user can always ensure the images are nested inside a div, which will inherit the sizing from its container

```html
<div class="image-grid"
  <div class="image-container"
    <img src=... data-sizes="auto" />
  </div>
  <div class="image-container"
    <img src=... data-sizes="auto" />
  </div>
</div>
```