### PR TITLE
fix(PE-807): correctly set sizes attribute for un-nested images

### DIFF
--- a/cypress/fixtures/index.css
+++ b/cypress/fixtures/index.css
@@ -21,7 +21,7 @@ article figure img {
   column-gap: 0px;
 }
 
-img[data-sizes='auto'] {
+img[ix-sizes='auto'] {
   display: block;
   width: 100%;
 }

--- a/cypress/fixtures/index.css
+++ b/cypress/fixtures/index.css
@@ -21,10 +21,9 @@ article figure img {
   column-gap: 0px;
 }
 
-#photos-grid img {
-  /* Just in case there are inline attributes */
-  width: 100% !important;
-  height: auto !important;
+img[data-sizes='auto'] {
+  display: block;
+  width: 100%;
 }
 
 /* media queries test the browser width and adjust

--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -245,7 +245,6 @@
           </a>
         </div>
     </section>
-    <script src="" async defer></script>
   </body>
   <footer>
     <hr />

--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -143,7 +143,7 @@
             data-test-id="sizes"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <!-- Invalid image -->
           <img
@@ -151,7 +151,7 @@
             data-test-id="invalid-img"
             test-path="this_wont_work!.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
             width="0px"
           />
         </figure>
@@ -181,56 +181,56 @@
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
       </article>
         <div class="button-group">

--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -5,12 +5,13 @@
 <!--[if gt IE 8]>      <html class="no-js"> <!--<![endif]-->
 <html>
   <head>
-    <script src="../../dist/imgix.min.js"></script>
+    <link rel="stylesheet" href="./index.css"/>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title></title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../../dist/imgix.min.js"></script>
     <meta property="ix:host" content="assets.imgix.net" />
     <!-- setting https to false for testing, not reccomended -->
     <meta property="ix:useHttps" content="false" />
@@ -18,7 +19,6 @@
     <meta property="ix:pathInputAttribute" content="test-path" />
     <meta property="ix:paramsInputAttribute" content="test-params" />
     <meta property="ix:sizesInputAttribute" content="sizes" />
-    <link rel="stylesheet" href="./index.css"/>
   </head>
   <body>
     <!--[if lt IE 7]>

--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -143,7 +143,7 @@
             data-test-id="sizes"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <!-- Invalid image -->
           <img
@@ -151,7 +151,7 @@
             data-test-id="invalid-img"
             test-path="this_wont_work!.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
             width="0px"
           />
         </figure>
@@ -181,56 +181,56 @@
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
       </article>
         <div class="button-group">

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -125,10 +125,22 @@ describe('On an invalid image or an image that has not loaded', () => {
         assert.isAtMost(newImgSize, 1500);
         expect(newImgSize).to.not.equal(404);
 
-        //check sizes HAS NOT changed on invalid image
+        // check sizes HAS NOT changed on invalid image
         cy.get('[data-test-id="invalid-img"]')
           .first()
           .then(($ele) => {
+            /**
+             * We want to test that autoSizes does not modify that image's sizes attribute.
+             * This is because an image that has not loaded should not get modified by the module.
+             * The invalid image, $ele, width here will evaluate to 100vw. This is despite the fact
+             * that it has not loaded. This is because $ele.width() is evaluated in the context of
+             * the test's runtime. At this point, other images on the page have loaded, changing the
+             * available width for the element. So it's not a good source of truth to ensure that
+             * sizes was not modified.
+             *
+             * Instead, we can use the elements width attribute, which does not get updated after the
+             * image above it (in the same container) loads.
+             */
             const imgSize = Number($ele.attr('sizes').split('px')[0]);
             const expectedSize = Number($ele.attr('width').split('px')[0]);
             assert.isAtLeast(imgSize, expectedSize);

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -10,7 +10,6 @@ describe('On a pages first render', () => {
     cy.get('[data-test-id="sizes"]', { timeout: 10000 }).each(($el) => {
       const expectedSize = Math.ceil($el.width());
       const imgSize = Number($el.attr('sizes').split('px')[0]);
-      cy.wait(100);
       assert.isAtMost(imgSize, 500);
       assert.isAtLeast(imgSize, expectedSize);
     });

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -10,6 +10,7 @@ describe('On a pages first render', () => {
     cy.get('[data-test-id="sizes"]', { timeout: 10000 }).each(($el) => {
       const expectedSize = Math.ceil($el.width());
       const imgSize = Number($el.attr('sizes').split('px')[0]);
+      cy.wait(100);
       assert.isAtMost(imgSize, 500);
       assert.isAtLeast(imgSize, expectedSize);
     });
@@ -130,7 +131,8 @@ describe('On an invalid image or an image that has not loaded', () => {
           .first()
           .then(($ele) => {
             const imgSize = Number($ele.attr('sizes').split('px')[0]);
-            assert.isAtLeast(imgSize, $ele.width());
+            const expectedSize = Number($ele.attr('width').split('px')[0]);
+            assert.isAtLeast(imgSize, expectedSize);
             assert.isAtMost(imgSize, 500);
           });
       });

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -131,15 +131,15 @@ describe('On an invalid image or an image that has not loaded', () => {
           .then(($ele) => {
             /**
              * We want to test that autoSizes does not modify that image's sizes attribute.
-             * This is because an image that has not loaded should not get modified by the module.
-             * The invalid image, $ele, width here will evaluate to 100vw. This is despite the fact
-             * that it has not loaded. This is because $ele.width() is evaluated in the context of
-             * the test's runtime. At this point, other images on the page have loaded, changing the
-             * available width for the element. So it's not a good source of truth to ensure that
-             * sizes was not modified.
+             * This is because an image that has not loaded should not get modified by the
+             * module. The invalid image, $ele, width here will evaluate to 100vw. This is
+             * despite the fact that it has not loaded. This is because $ele.width() is
+             * evaluated in the context of the test's runtime. At this point, other images
+             * on the page have loaded, changing the available width for the element. So
+             * it's not a good source of truth to ensure that sizes was not modified.
              *
-             * Instead, we can use the elements width attribute, which does not get updated after the
-             * image above it (in the same container) loads.
+             * Instead, we can use the elements width attribute, which does not get
+             * updated after the image above it (in the same container) loads.
              */
             const imgSize = Number($ele.attr('sizes').split('px')[0]);
             const expectedSize = Number($ele.attr('width').split('px')[0]);

--- a/index.css
+++ b/index.css
@@ -27,6 +27,11 @@ article figure img {
   height: auto !important;
 }
 
+img[data-sizes='auto'] {
+  display: block;
+  width: 100%;
+}
+
 .size-info {
   z-index: 1;
   position: relative;

--- a/index.css
+++ b/index.css
@@ -27,7 +27,7 @@ article figure img {
   height: auto !important;
 }
 
-img[data-sizes='auto'] {
+img[ix-sizes='auto'] {
   display: block;
   width: 100%;
 }

--- a/index.html
+++ b/index.html
@@ -5,12 +5,13 @@
 <!--[if gt IE 8]>      <html class="no-js"> <!--<![endif]-->
 <html>
   <head>
-    <script src="./dist/imgix.min.js"></script>
+    <link rel="stylesheet" href="./index.css"/>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title></title>
     <meta name="description" content="" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="./dist/imgix.min.js"></script>
     <meta property="ix:host" content="assets.imgix.net" />
     <!-- setting https to false for testing, not reccomended -->
     <meta property="ix:useHttps" content="false" />
@@ -18,7 +19,6 @@
     <meta property="ix:pathInputAttribute" content="test-path" />
     <meta property="ix:paramsInputAttribute" content="test-params" />
     <meta property="ix:sizesInputAttribute" content="sizes" />
-    <link rel="stylesheet" href="./index.css"/>
   </head>
   <body>
     <!--[if lt IE 7]>

--- a/index.html
+++ b/index.html
@@ -172,7 +172,7 @@
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
             data-test-id="sizes"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+            data-sizes="auto"
           />
         </figure>
         <div class="button-group">
@@ -176,52 +176,61 @@
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
+          />
+          <section>
+            <img
+              data-test-id="sizes-grid"
+              alt="img-grid-img"
+              data-sizes="auto"
+              test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+              test-params="{}"
+            />
+        </section>
+          <img
+            data-test-id="sizes-grid"
+            data-sizes="auto"
+            alt="img-grid-img"
+            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+            test-params="{}"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
+            data-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            sizes="auto"
-          />
-          <img
-            data-test-id="sizes-grid"
-            alt="img-grid-img"
-            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
-            test-params="{}"
-            sizes="auto"
           />
       </article>
         <div class="button-group">

--- a/index.html
+++ b/index.html
@@ -245,7 +245,6 @@
           </a>
         </div>
     </section>
-    <script src="" async defer></script>
     <script src="index.js"async defer></script>
   </body>
   <footer>

--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
             data-test-id="sizes"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
         </figure>
         <div class="button-group">
@@ -172,25 +172,25 @@
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
-            data-sizes="auto"
+            ix-sizes="auto"
           />
           <img
             data-test-id="sizes-grid"
-            data-sizes="auto"
+            ix-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
           />
           <img
             data-test-id="sizes-grid"
-            data-sizes="auto"
+            ix-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
           />
           <img
             data-test-id="sizes-grid"
-            data-sizes="auto"
+            ix-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
@@ -199,35 +199,35 @@
             <img
               data-test-id="sizes-grid"
               alt="img-grid-img"
-              data-sizes="auto"
+              ix-sizes="auto"
               test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
               test-params="{}"
             />
         </section>
           <img
             data-test-id="sizes-grid"
-            data-sizes="auto"
+            ix-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
           />
           <img
             data-test-id="sizes-grid"
-            data-sizes="auto"
+            ix-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
           />
           <img
             data-test-id="sizes-grid"
-            data-sizes="auto"
+            ix-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
           />
           <img
             data-test-id="sizes-grid"
-            data-sizes="auto"
+            ix-sizes="auto"
             alt="img-grid-img"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -187,15 +187,16 @@ var ImgixTag = (function () {
 
   ImgixTag.prototype.sizes = function () {
     var existingSizes = this.el.getAttribute('sizes');
-    var dataSizes = this.el.getAttribute('data-sizes');
+    var dataSizes = this.el.getAttribute('ix-sizes');
     const el = this.el;
     const _window = this.window;
 
-    if (existingSizes && dataSizes !== 'auto') {
-      return existingSizes;
+    if (existingSizes || dataSizes !== 'auto') {
+      return existingSizes ? existingSizes : '100vw';
     } else if (dataSizes === 'auto') {
       return autoSize.updateOnResize({ el, existingSizes, dataSizes, _window });
     } else {
+      // TODO(luis): is this dead code? Unlikely to be reached ever
       return '100vw';
     }
   };

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -192,7 +192,7 @@ var ImgixTag = (function () {
     const _window = this.window;
 
     if (existingSizes || ixSizes !== 'auto') {
-      return existingSizes ? existingSizes : '100vw';
+      return existingSizes != null ? existingSizes : '100vw';
     } else if (ixSizes === 'auto') {
       return autoSize.updateOnResize({ el, existingSizes, ixSizes, _window });
     } else {

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -187,13 +187,14 @@ var ImgixTag = (function () {
 
   ImgixTag.prototype.sizes = function () {
     var existingSizes = this.el.getAttribute('sizes');
+    var dataSizes = this.el.getAttribute('data-sizes');
     const el = this.el;
     const _window = this.window;
 
-    if (existingSizes && existingSizes !== 'auto') {
+    if (existingSizes && dataSizes !== 'auto') {
       return existingSizes;
-    } else if (existingSizes === 'auto') {
-      return autoSize.updateOnResize({ el, existingSizes, _window });
+    } else if (dataSizes === 'auto') {
+      return autoSize.updateOnResize({ el, existingSizes, dataSizes, _window });
     } else {
       return '100vw';
     }

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -187,14 +187,14 @@ var ImgixTag = (function () {
 
   ImgixTag.prototype.sizes = function () {
     var existingSizes = this.el.getAttribute('sizes');
-    var dataSizes = this.el.getAttribute('ix-sizes');
+    var ixSizes = this.el.getAttribute('ix-sizes');
     const el = this.el;
     const _window = this.window;
 
-    if (existingSizes || dataSizes !== 'auto') {
+    if (existingSizes || ixSizes !== 'auto') {
       return existingSizes ? existingSizes : '100vw';
-    } else if (dataSizes === 'auto') {
-      return autoSize.updateOnResize({ el, existingSizes, dataSizes, _window });
+    } else if (ixSizes === 'auto') {
+      return autoSize.updateOnResize({ el, existingSizes, ixSizes, _window });
     } else {
       // TODO(luis): is this dead code? Unlikely to be reached ever
       return '100vw';

--- a/src/autoSize.js
+++ b/src/autoSize.js
@@ -67,8 +67,8 @@ const imageLoaded = ({ el }) => {
 };
 
 // Returns true if img has sizes attr and the img has loaded.
-const imgCanBeSized = ({ el, existingSizes, dataSizes, elHasAttributes }) => {
-  if (!existingSizes && !dataSizes) {
+const imgCanBeSized = ({ el, existingSizes, ixSizes, elHasAttributes }) => {
+  if (!existingSizes && !ixSizes) {
     console.warn(
       'Imgix.js: attempted to set sizes attribute on element without existing sizes attribute value'
     );
@@ -88,7 +88,7 @@ const imgCanBeSized = ({ el, existingSizes, dataSizes, elHasAttributes }) => {
 const getCurrentSize = ({
   el,
   existingSizes,
-  dataSizes,
+  ixSizes,
   elHasAttributes,
   _window,
 }) => {
@@ -100,7 +100,7 @@ const getCurrentSize = ({
   let currentSize = imgCanBeSized({
     el,
     existingSizes,
-    dataSizes,
+    ixSizes,
     elHasAttributes,
     _window,
   })
@@ -117,7 +117,7 @@ const getCurrentSize = ({
 const resizeElement = ({
   el,
   existingSizes,
-  dataSizes,
+  ixSizes,
   _window,
   elHasAttributes,
 }) => {
@@ -126,7 +126,7 @@ const resizeElement = ({
   const currentSize = getCurrentSize({
     el,
     existingSizes,
-    dataSizes,
+    ixSizes,
     elHasAttributes,
     _window,
   });
@@ -140,14 +140,14 @@ const resizeElement = ({
 };
 
 // Function that makes throttled rAF calls to avoid multiple calls in the same frame
-const updateOnResize = ({ el, existingSizes, dataSizes, _window }) => {
+const updateOnResize = ({ el, existingSizes, ixSizes, _window }) => {
   // debounce fn
   const elHasAttributes = el.hasAttributes();
 
   const requestIdleCallback = util.rICShim(_window);
   const runDebounce = util.debounce(() => {
     requestIdleCallback(() =>
-      resizeElement({ el, existingSizes, dataSizes, _window, elHasAttributes })
+      resizeElement({ el, existingSizes, ixSizes, _window, elHasAttributes })
     );
   }, DEBOUNCE_TIMEOUT);
   // Listen for resize


### PR DESCRIPTION
This PR modifies the auto sizing behavior so that it reacts to `ix-sizes` and not `sizes`. 

It does this so that:

1. CSS styles can be more easily defined on images that will use the auto sizing feature

2. It is easier to differentiate between user defined sizes and library defined `sizes`

The PR also:
- updates the conditional that handles existing `sizes` attribute values to ensure they're always respected 
- updates the test fixtures to use `ix-sizes`
- updates the example `index` files to use `ix-sizes`
- updates the example `index` to include nested and un-nested image tags
- updates the `autoSize.getWidth()` function to ensure we don't always default to `parent.offsetWidth` if `width` is less than the minimum.
> `ix-sizes` is used in-lieu-of `data-sizes` to avoid collisions with the `lazysizes.js` library.

## Up for discussion

This implementation assumes the user makes use of either:

1) CSS styles to define image widths,  which can almost always be achieved by adding something like the bellow ruleset.

```css
img[ix-sizes='auto'] {
  display: block;
  width: 100%;
}
```

2) Appropriate element nesting to ensure the images always have a parent with the corresponding width property defined.

```html
<div class="image-grid"
  <div class="image-container"
    <img src=... ix-sizes="auto" />
  </div>
  <div class="image-container"
    <img src=... ix-sizes="auto" />
  </div>
</div>
```

See [this](https://github.com/imgix/imgix.js/pull/297#discussion_r634844024) comment for more.