### PR TITLE
fix(sizes): use ix-sizes as sizes fallback if ix-sizes not auto

### DIFF
--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -245,6 +245,34 @@
           </a>
         </div>
     </section>
+    <section>
+      <p>Images where `sizes` value is defined and not modified by library or
+        where `sizes` and `ix-sizes` are not defined and set to browser default
+        by library.
+      </p>
+      <div>
+        <figure>
+          <img
+            alt="sizes-auto-first-img"
+            data-test-id="sizes-defined"
+            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+            test-params="{}"
+            sizes="25.123vw"
+            ix-sizes="auto"
+          />
+        </figure>
+        </div>
+        <div>
+        <figure>
+          <img
+            alt="sizes-auto-first-img"
+            data-test-id="sizes-defined-as-false"
+            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+            test-params="{}"
+          />
+        </figure>
+        </div>
+    </section>
   </body>
   <footer>
     <hr />

--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -272,6 +272,29 @@
           />
         </figure>
         </div>
+        <div>
+        <figure>
+          <img
+            alt="sizes-not-set-ix-sizes-not-auto"
+            data-test-id="sizes-not-set-ix-sizes-not-auto"
+            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+            test-params="{}"
+            ix-sizes="50vw"
+          />
+        </figure>
+        </div>
+        <div>
+        <figure>
+          <img
+            alt="sizes-set-ix-sizes-not-auto"
+            data-test-id="sizes-set-ix-sizes-not-auto"
+            test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
+            test-params="{}"
+            sizes="100vw"
+            ix-sizes="50vw"
+          />
+        </figure>
+        </div>
     </section>
   </body>
   <footer>

--- a/cypress/fixtures/index.html
+++ b/cypress/fixtures/index.html
@@ -253,7 +253,7 @@
       <div>
         <figure>
           <img
-            alt="sizes-auto-first-img"
+            alt="sizes-defined"
             data-test-id="sizes-defined"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
@@ -265,8 +265,8 @@
         <div>
         <figure>
           <img
-            alt="sizes-auto-first-img"
-            data-test-id="sizes-defined-as-false"
+            alt="sizes-not-set"
+            data-test-id="sizes-not-set"
             test-path="+%3C%3E%5B%5D%7B%7D%7C%5C%5E%25.jpg"
             test-params="{}"
           />

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -1,3 +1,39 @@
+describe('If `sizes` is already set on the image', () => {
+  before(() => {
+    cy.visit('/cypress/fixtures/index.html');
+  });
+  beforeEach(() => {
+    cy.fixture('config.js').as('config');
+  });
+
+  it('It leaves sizes as is even if `ix-sizes` is `auto`', () => {
+    cy.get('[data-test-id="sizes-defined"]', { timeout: 10000 }).each(($el) => {
+      const expectedSize = '25.123vw';
+      const imgSize = $el.attr('sizes');
+      expect(imgSize).to.equal(expectedSize);
+    });
+  });
+});
+
+describe('If `sizes` and `ix-sizes` not set', () => {
+  before(() => {
+    cy.visit('/cypress/fixtures/index.html');
+  });
+  beforeEach(() => {
+    cy.fixture('config.js').as('config');
+  });
+
+  it('It sets `sizes` to browser default', () => {
+    cy.get('[data-test-id="sizes-defined-as-false"]', { timeout: 10000 }).each(
+      ($el) => {
+        const expectedSize = '100vw';
+        const imgSize = $el.attr('sizes');
+        expect(imgSize).to.equal(expectedSize);
+      }
+    );
+  });
+});
+
 describe('On a pages first render', () => {
   before(() => {
     cy.visit('/cypress/fixtures/index.html');

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -13,6 +13,16 @@ describe('If `sizes` is already set on the image', () => {
       expect(imgSize).to.equal(expectedSize);
     });
   });
+
+  it('It leaves sizes as is if `ix-sizes` is not `auto`', () => {
+    cy.get('[data-test-id="sizes-set-ix-sizes-not-auto"]', {
+      timeout: 10000,
+    }).each(($el) => {
+      const expectedSize = $el.attr('ix-sizes');
+      const imgSize = $el.attr('sizes');
+      expect(imgSize).not.to.equal(expectedSize);
+    });
+  });
 });
 
 describe('If `sizes` and `ix-sizes` not set', () => {
@@ -26,6 +36,25 @@ describe('If `sizes` and `ix-sizes` not set', () => {
   it('It sets `sizes` to browser default', () => {
     cy.get('[data-test-id="sizes-not-set"]', { timeout: 10000 }).each(($el) => {
       const expectedSize = '100vw';
+      const imgSize = $el.attr('sizes');
+      expect(imgSize).to.equal(expectedSize);
+    });
+  });
+});
+
+describe('If `sizes` not set and `ix-sizes` not "auto"', () => {
+  before(() => {
+    cy.visit('/cypress/fixtures/index.html');
+  });
+  beforeEach(() => {
+    cy.fixture('config.js').as('config');
+  });
+
+  it('It sets `sizes` to "ix-sizes"', () => {
+    cy.get('[data-test-id="sizes-not-set-ix-sizes-not-auto"]', {
+      timeout: 10000,
+    }).each(($el) => {
+      const expectedSize = $el.attr('ix-sizes');
       const imgSize = $el.attr('sizes');
       expect(imgSize).to.equal(expectedSize);
     });

--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -24,13 +24,11 @@ describe('If `sizes` and `ix-sizes` not set', () => {
   });
 
   it('It sets `sizes` to browser default', () => {
-    cy.get('[data-test-id="sizes-defined-as-false"]', { timeout: 10000 }).each(
-      ($el) => {
-        const expectedSize = '100vw';
-        const imgSize = $el.attr('sizes');
-        expect(imgSize).to.equal(expectedSize);
-      }
-    );
+    cy.get('[data-test-id="sizes-not-set"]', { timeout: 10000 }).each(($el) => {
+      const expectedSize = '100vw';
+      const imgSize = $el.attr('sizes');
+      expect(imgSize).to.equal(expectedSize);
+    });
   });
 });
 

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -191,13 +191,14 @@ var ImgixTag = (function () {
     const el = this.el;
     const _window = this.window;
 
-    if (existingSizes || ixSizes !== 'auto') {
-      return existingSizes != null ? existingSizes : '100vw';
-    } else if (ixSizes === 'auto') {
+    // if ixSizes not `auto` and no existingSizes, set `sizes` to `ix-sizes`
+    if (existingSizes == null && ixSizes !== 'auto') {
+      return ixSizes ? ixSizes : '100vw';
+    } else if (existingSizes == null && ixSizes === 'auto') {
       return autoSize.updateOnResize({ el, existingSizes, ixSizes, _window });
     } else {
-      // TODO(luis): is this dead code? Unlikely to be reached ever
-      return '100vw';
+      // if no existingSizes and no ixSizes, use browser default `100vw`
+      return existingSizes ? existingSizes : '100vw';
     }
   };
 

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -191,13 +191,22 @@ var ImgixTag = (function () {
     const el = this.el;
     const _window = this.window;
 
-    // if ixSizes not `auto` and no existingSizes, set `sizes` to `ix-sizes`
+    /**
+     *
+     * The conditionals bellow decide when to override the value for `sizes` for
+     * the given element.
+     *
+     * - If `sizes` set, we leave the value as is even if `ix-sizes` is `auto`
+     * - If `sizes` not set and `ix-sizes` not auto, set `sizes` to `ix-sizes`
+     * - If `sizes` not set and `ix-sizes` is auto, set `sizes` automatically
+     * - If `sizes` and `ix-sizes` not set, set `sizes` to browser default
+     */
+
     if (existingSizes == null && ixSizes !== 'auto') {
       return ixSizes ? ixSizes : '100vw';
     } else if (existingSizes == null && ixSizes === 'auto') {
       return autoSize.updateOnResize({ el, existingSizes, ixSizes, _window });
     } else {
-      // if no existingSizes and no ixSizes, use browser default `100vw`
       return existingSizes ? existingSizes : '100vw';
     }
   };


### PR DESCRIPTION
This PR setts `sizes` from `ix-sizes` if it is set to a value that's not `'auto'`.

Addresses [this comment](https://github.com/imgix/imgix.js/pull/297#discussion_r636687300) on #297 ,