### PR TITLE
fix: change useHttps to true in demo file to fix blocked assets error

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     <script src="./dist/imgix.min.js"></script>
     <meta property="ix:host" content="assets.imgix.net" />
     <!-- setting https to false for testing, not reccomended -->
-    <meta property="ix:useHttps" content="false" />
+    <meta property="ix:useHttps" content="true" />
     <meta property="ix:srcInputAttribute" content="test-src" />
     <meta property="ix:pathInputAttribute" content="test-path" />
     <meta property="ix:paramsInputAttribute" content="test-params" />


### PR DESCRIPTION
Browsers were blocking the image requests since the expected scheme,
https, did not match the src URL scheme, http. The meta property,
ix:useHttps, had to be set to "true" to fix this issue.
