### PR TITLE
fix: bump version to match current

### DIFF
--- a/src/imgix.js
+++ b/src/imgix.js
@@ -2,7 +2,7 @@ var ImgixTag = require('./ImgixTag.js'),
   util = require('./util.js'),
   defaultConfig = require('./defaultConfig');
 
-var VERSION = '3.4.2';
+var VERSION = '3.5.0';
 
 global.imgix = {
   init: function (opts) {


### PR DESCRIPTION
index.js had not been updated to relfect the currently released version
which was affecting out internal reporting for this version of the
library. This commit fixes the version number.
