### PR TITLE
feat(imgixtag): add nolazyload class to selectively disable lazy loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,18 @@ Image Tag Example:
 >
 ```
 
+If lazy loading is required for some images but undesirable for others, we provide the optional class `nolazyload` to disable lazy loading on select assets.
+
+Image Tag Example:
+
+<img
+  ix-src="https://assets.imgix.net/unsplash/hotairballoon.jpg?w=300&amp;h=500&amp;fit=crop&amp;crop=right"
+  alt="A hot air balloon on a sunny day"
+  sizes="100vw"
+  class="nolazyload"
+>
+```
+
 ### Custom Input Attributes
 
 `imgix.js` defaults to pulling its data from the `ix-src`, `ix-path`, `ix-params`, and `ix-host` attributes. If custom input attributes are desired, they can be specified by changing some configuration settings. This can be useful if, say, there is a concern about W3C compliance.

--- a/spec/ImgixTagSpec.js
+++ b/spec/ImgixTagSpec.js
@@ -169,6 +169,27 @@ describe('ImgixTag', function() {
       expect(tag.ixHostVal).toEqual('different-source.imgix.net');
     });
 
+    it("overrides custom 'srcAttribute' with 'src' when class = 'nolazyload'", function() {
+      global.imgix.config.srcAttribute = 'src-attribute-test';
+      global.mockElement.setAttribute('className', 'nolazyload');
+      var tag = new ImgixTag(global.mockElement, global.imgix.config);
+      expect(tag['src']).toBeDefined();
+    });
+
+    it("overrides custom 'srcsetAttribute' with 'srcset' when class = 'nolazyload'", function() {
+      global.imgix.config.srcsetAttribute = 'srcset-attribute-test';
+      global.mockElement.setAttribute('className', 'nolazyload');
+      var tag = new ImgixTag(global.mockElement, global.imgix.config);
+      expect(tag['srcset']).toBeDefined();
+    });
+
+    it("overrides custom 'sizesAttribute' with 'sizes' when class = 'nolazyload'", function() {
+      global.imgix.config.sizesAttribute = 'sizes-attribute-test';
+      global.mockElement.setAttribute('className', 'nolazyload');
+      var tag = new ImgixTag(global.mockElement, global.imgix.config);
+      expect(tag['sizes']).toBeDefined();
+    });
+
     it('errors if neither `imgix.host` or `ix-host` are specified, but the passed element has `ix-path`', function() {
       global.mockElement['ix-path'] = 'dogs.jpg';
       var expected_warning =

--- a/src/ImgixTag.js
+++ b/src/ImgixTag.js
@@ -45,6 +45,15 @@ var ImgixTag = (function () {
     this.baseUrl = this._buildBaseUrl();
     this.baseUrlWithoutQuery = this.baseUrl.split('?')[0];
 
+    //manual override to use sizes, srcset, and src when lazyloading
+    if(util.isString(this.el.className)){
+      if (this.el.className.includes("nolazyload")){
+        this.settings.sizesAttribute = "sizes";
+        this.settings.srcsetAttribute = "srcset";
+        this.settings.srcAttribute = "src";
+      }
+    }
+
     if (util.isString(this.settings.sizesAttribute)) {
       this.el.setAttribute(this.settings.sizesAttribute, this.sizes());
     }


### PR DESCRIPTION
Added an optional class 'nolazyload' that allows the end user to manually disable lazy loading for select elements when using lazysizes. The class functions by adding a simple manual override for the 'srcAttribute', 'srcsetAttribute', and 'sizesAttribute' settings, allowing the user to disable the 'data-*' settings both when using meta-tags and while setting the values with JavaScript. 

 The current testing for the class consists of unit tests for the effect of 'nolazyload' with overridden attribute settings. Potential followup testing might include full integration tests for 'nolazyload' used in conjunction with the third party lazysizes library.