### PR TITLE
chore(deploy): configured semantic release config to use single quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
               "files": [
                 "src/imgix.js"
               ],
-              "from": "var VERSION = \".*\"",
+              "from": "var VERSION = '.*'",
               "to": "var VERSION = \"${nextRelease.version}\"",
               "results": [
                 {


### PR DESCRIPTION
Semantic Release was configured to use double quotes for the version number so updated the config to use single quotes as is currently used in the library.