### PR TITLE
test: add skip for brittle debounce tasks

### DIFF
--- a/cypress/integration/sizesAutoSpec.js
+++ b/cypress/integration/sizesAutoSpec.js
@@ -114,7 +114,8 @@ describe('When a page gets resized', () => {
         performance: 97,
       });
     });
-    it(`Does not update size before debounce is finished`, () => {
+    // [A] TODO: Disabling brittle tests for now
+    it.skip(`Does not update size before debounce is finished`, () => {
       cy.get('[data-test-id="sizes"]')
         .first()
         .then(($el) => {
@@ -131,7 +132,8 @@ describe('When a page gets resized', () => {
           assert.isAtLeast(imgSize, expectedSize);
         });
     });
-    it('Updates size after debounce has finished', () => {
+    // [A] TODO: Disabling brittle tests for now
+    it.skip('Updates size after debounce has finished', () => {
       cy.viewport(1500, 500);
       cy.wait(300);
       cy.get('[data-test-id="sizes"]')


### PR DESCRIPTION
Skips brittle tests in `sizesAutoSpec.js`. Solutions for the underlying cause have been discussed offline, and work is planned on the issue - as such, we add a temporary fix to prevent CircleCI from blocking dependency updates.

# Before
Brittle tests in the `sizesAutoSpec.js` integration test file intermittently blocked PRs and dependency updates by Renovate.

# After
Brittle tests in `sizesAutoSpec.js` are skipped, marked with a `TODO`.