### PR TITLE
fix: adds a missing html tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ If lazy loading is required for some images but undesirable for others, we provi
 
 Image Tag Example:
 
+``` html
 <img
   ix-src="https://assets.imgix.net/unsplash/hotairballoon.jpg?w=300&amp;h=500&amp;fit=crop&amp;crop=right"
   alt="A hot air balloon on a sunny day"


### PR DESCRIPTION
## Description

This PR adds a missing opening `html` bracket which is causing some syntax issues for the docs page

_Custom Input Attributes should not be in a html block, but the <img> tag should be_: 
<img width="600" alt="Screen Shot 2023-01-09 at 3 31 53 PM" src="https://user-images.githubusercontent.com/49009626/211429231-80d29664-17a6-41c6-bfda-eb31e0b0ad94.png">

The [imgix.js docs page](https://docs.imgix.com/libraries/imgix-js) is displaying `### Custom Input Attributes` incorrectly and chaining display issues:
<img width="600" alt="Screen Shot 2023-01-09 at 3 31 53 PM" src="https://user-images.githubusercontent.com/49009626/211429479-6b155670-0cf2-4396-8d09-21233a40ade8.png">

This is also causing text on mobile screen to go off the page and the seo crawlers are throwing mobility view errors(frontend is investigating some crawler errors):
![Screen Shot 2023-01-09 at 3 39 46 PM](https://user-images.githubusercontent.com/49009626/211429787-8c779e5e-a1a2-45fc-bc80-87ce00022148.png)

## Links
[Jira](https://imgix.atlassian.net/browse/PE-3192)

